### PR TITLE
Base.js: use scrollable instead of autoScroll

### DIFF
--- a/web/app/view/dialog/Base.js
+++ b/web/app/view/dialog/Base.js
@@ -20,7 +20,7 @@ Ext.define('Traccar.view.dialog.Base', {
 
     bodyPadding: Traccar.Style.normalPadding,
     resizable: false,
-    autoScroll: true,
+    scrollable: true,
     constrain: true,
 
     initComponent: function () {


### PR DESCRIPTION
autoScroll is deprecated:
https://docs.sencha.com/extjs/6.2.0/classic/Ext.window.Window.html#cfg-autoScroll