### PR TITLE
Add support of engine hours in milliseconds

### DIFF
--- a/web/app/Application.js
+++ b/web/app/Application.js
@@ -107,7 +107,8 @@ Ext.define('Traccar.Application', {
         'AllNotificationTypes',
         'Maintenances',
         'AllMaintenances',
-        'MaintenanceTypes'
+        'MaintenanceTypes',
+        'HoursUnits'
     ],
 
     controllers: [

--- a/web/app/AttributeFormatter.js
+++ b/web/app/AttributeFormatter.js
@@ -60,11 +60,16 @@ Ext.define('Traccar.AttributeFormatter', {
         return Ext.getStore('VolumeUnits').convertValue(value, Traccar.app.getAttributePreference('volumeUnit'));
     },
 
+    hoursFormatter: function (value) {
+        return Ext.getStore('HoursUnits').formatValue(value, 'h');
+    },
+
+    hoursConverter: function (value) {
+        return Ext.getStore('HoursUnits').convertValue(value, 'h');
+    },
+
     durationFormatter: function (value) {
-        var hours, minutes;
-        hours = Math.floor(value / 3600000);
-        minutes = Math.floor(value % 3600000 / 60000);
-        return hours + ' ' + Strings.sharedHourAbbreviation + ' ' + minutes + ' ' + Strings.sharedMinuteAbbreviation;
+        return Ext.getStore('HoursUnits').formatValue(value, 'h', true);
     },
 
     deviceIdFormatter: function (value) {
@@ -251,6 +256,8 @@ Ext.define('Traccar.AttributeFormatter', {
                 return this.numberFormatterFactory(Traccar.Style.numberPrecision, '&deg;C');
             case 'volume':
                 return this.volumeFormatter;
+            case 'hours':
+                return this.hoursFormatter;
             case 'consumption':
                 return this.numberFormatterFactory(Traccar.Style.numberPrecision, Strings.sharedLiterPerHourAbbreviation);
             default:
@@ -268,6 +275,8 @@ Ext.define('Traccar.AttributeFormatter', {
                 return this.speedConverter;
             case 'volume':
                 return this.volumeConverter;
+            case 'hours':
+                return this.hoursConverter;
             default:
                 return function (value) {
                     return value;
@@ -280,6 +289,8 @@ Ext.define('Traccar.AttributeFormatter', {
             return Ext.getStore('SpeedUnits').formatValue(value, Traccar.app.getAttributePreference('speedUnit', 'kn'), true);
         } else if (attribute && attribute.get('dataType') === 'distance') {
             return Ext.getStore('DistanceUnits').formatValue(value, Traccar.app.getAttributePreference('distanceUnit', 'km'), true);
+        } else if (attribute && attribute.get('dataType') === 'hours') {
+            return Ext.getStore('HoursUnits').formatValue(value, 'h', true);
         } else {
             return value;
         }

--- a/web/app/store/HoursUnits.js
+++ b/web/app/store/HoursUnits.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2018 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+Ext.define('Traccar.store.HoursUnits', {
+    extend: 'Ext.data.Store',
+    fields: ['key', 'name', 'fullName'],
+
+    data: [{
+        key: 'h',
+        name: Strings.sharedHourAbbreviation,
+        fullName: Strings.sharedHour
+    }],
+
+    convertValue: function (value, unit, back) {
+        return back ? value * 3600000 : value / 3600000;
+    },
+
+    formatValue: function (value, unit, convert) {
+        var hours, minutes;
+        if (convert) {
+            hours = Math.floor(value / 3600000);
+            minutes = Math.floor(value % 3600000 / 60000);
+        } else {
+            hours = Math.floor(value);
+            minutes = Math.floor(value % 1 * 60);
+        }
+        return hours + ' ' + Strings.sharedHourAbbreviation + ' ' + minutes + ' ' + Strings.sharedMinuteAbbreviation;
+    }
+});

--- a/web/app/store/PositionAttributes.js
+++ b/web/app/store/PositionAttributes.js
@@ -90,7 +90,8 @@ Ext.define('Traccar.store.PositionAttributes', {
     }, {
         key: 'hours',
         name: Strings.positionHours,
-        valueType: 'string'
+        valueType: 'number',
+        dataType: 'hours'
     }, {
         key: 'steps',
         name: Strings.positionSteps,

--- a/web/app/view/CustomNumberField.js
+++ b/web/app/view/CustomNumberField.js
@@ -72,6 +72,16 @@ Ext.define('Traccar.view.CustomNumberField', {
                         }
                     };
                     break;
+                case 'hours':
+                    config.units = {};
+                    config.units.getStore = function () {
+                        return Ext.getStore('HoursUnits');
+                    };
+                    config.units.getValue = function () {
+                        return 'h';
+                    };
+                    unitName = Strings.sharedHourAbbreviation;
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
Added "one-item-store" to leave approach the same.

![image](https://user-images.githubusercontent.com/5688080/40778710-9ef7dfe0-64eb-11e8-94c5-7cf7a69b1445.png)

fix https://github.com/traccar/traccar/issues/3532