### PR TITLE
Work around for Firefox select and touch issues

### DIFF
--- a/web/app/Application.js
+++ b/web/app/Application.js
@@ -21,7 +21,8 @@ Ext.define('Traccar.Application', {
 
     requires: [
         'Traccar.Style',
-        'Traccar.AttributeFormatter'
+        'Traccar.AttributeFormatter',
+        'Traccar.view.TouchFix62'
     ],
 
     models: [

--- a/web/app/view/TouchFix62.js
+++ b/web/app/view/TouchFix62.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Anton Tananaev (anton@traccar.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * workaround for bug in ExtJs 6.2.0.
+ * Resolved in current yet unreleased version
+ */
+
+Ext.define('Traccar.view.TouchFix62', {
+    override: 'Ext.dom.Element'
+},
+function(){
+    var additiveEvents = this.prototype.additiveEvents,
+        eventMap = this.prototype.eventMap;
+    if(Ext.supports.TouchEvents && Ext.firefoxVersion >= 52 && Ext.os.is.Desktop){
+        eventMap['touchstart'] = 'mousedown';
+        eventMap['touchmove'] = 'mousemove';
+        eventMap['touchend'] = 'mouseup';
+        eventMap['touchcancel'] = 'mouseup';
+        eventMap['click'] = 'click';
+        eventMap['dblclick'] = 'dblclick';
+        additiveEvents['mousedown'] = 'mousedown';
+        additiveEvents['mousemove'] = 'mousemove';
+        additiveEvents['mouseup'] = 'mouseup';
+        additiveEvents['touchstart'] = 'touchstart';
+        additiveEvents['touchmove'] = 'touchmove';
+        additiveEvents['touchend'] = 'touchend';
+        additiveEvents['touchcancel'] = 'touchcancel';
+
+        additiveEvents['pointerdown'] = 'mousedown';
+        additiveEvents['pointermove'] = 'mousemove';
+        additiveEvents['pointerup'] = 'mouseup';
+        additiveEvents['pointercancel'] = 'mouseup';
+    }
+})

--- a/web/app/view/TouchFix62.js
+++ b/web/app/view/TouchFix62.js
@@ -15,18 +15,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * workaround for bug in ExtJs 6.2.0.
+/*
+ * Workaround for bug in ExtJs 6.2.0.
  * Resolved in current yet unreleased version
  */
 
 Ext.define('Traccar.view.TouchFix62', {
     override: 'Ext.dom.Element'
 },
-function(){
+function () {
     var additiveEvents = this.prototype.additiveEvents,
         eventMap = this.prototype.eventMap;
-    if(Ext.supports.TouchEvents && Ext.firefoxVersion >= 52 && Ext.os.is.Desktop){
+    if (Ext.supports.TouchEvents && Ext.firefoxVersion >= 52 && Ext.os.is.Desktop) {
         eventMap['touchstart'] = 'mousedown';
         eventMap['touchmove'] = 'mousemove';
         eventMap['touchend'] = 'mouseup';
@@ -40,10 +40,9 @@ function(){
         additiveEvents['touchmove'] = 'touchmove';
         additiveEvents['touchend'] = 'touchend';
         additiveEvents['touchcancel'] = 'touchcancel';
-
         additiveEvents['pointerdown'] = 'mousedown';
         additiveEvents['pointermove'] = 'mousemove';
         additiveEvents['pointerup'] = 'mouseup';
         additiveEvents['pointercancel'] = 'mouseup';
     }
-})
+});


### PR DESCRIPTION
This is a result of issues experienced using firefox as shown this stack overflow thread. This issues occur mostly on high DPI screens.
As explained in this link: https://stackoverflow.com/questions/43236899/extjs-6-2-classic-does-not-work-with-firefox-and-a-touchscreen