### PR TITLE
Fix bug with selecting device second time from the devices grid

### DIFF
--- a/web/app/view/edit/Devices.js
+++ b/web/app/view/edit/Devices.js
@@ -75,7 +75,8 @@ Ext.define('Traccar.view.edit.Devices', {
     },
 
     listeners: {
-        selectionchange: 'onSelectionChange'
+        selectionchange: 'onSelectionChange',
+        rowclick: 'onClick'
     },
 
     viewConfig: {

--- a/web/app/view/edit/Devices.js
+++ b/web/app/view/edit/Devices.js
@@ -75,8 +75,8 @@ Ext.define('Traccar.view.edit.Devices', {
     },
 
     listeners: {
-        selectionchange: 'onSelectionChange',
-        rowclick: 'onClick'
+        rowclick: 'onSelectionChange',
+        itemkeyup: 'onSelectionChange'
     },
 
     viewConfig: {

--- a/web/app/view/edit/DevicesController.js
+++ b/web/app/view/edit/DevicesController.js
@@ -109,16 +109,7 @@ Ext.define('Traccar.view.edit.DevicesController', {
         this.lookupReference('deviceCommandButton').setDisabled(empty || readonly);
     },
 
-    onSelectionChange: function (selection, selected) {
-        this.updateButtons(selected);
-        if (selected.length > 0) {
-            this.fireEvent('selectdevice', selected[0], true);
-        } else {
-            this.fireEvent('deselectfeature');
-        }
-    },
-
-    onClick: function (el, record) {
+    onSelectionChange: function (el, record) {
         if (record !== undefined) {
             this.updateButtons([record]);
             this.fireEvent('selectdevice', record, true);

--- a/web/app/view/edit/DevicesController.js
+++ b/web/app/view/edit/DevicesController.js
@@ -118,6 +118,13 @@ Ext.define('Traccar.view.edit.DevicesController', {
         }
     },
 
+    onClick: function (el, record) {
+        if (record !== undefined) {
+            this.updateButtons([record]);
+            this.fireEvent('selectdevice', record, true);
+        }
+    },
+
     selectDevice: function (device) {
         this.getView().getSelectionModel().select([device], false, true);
         this.updateButtons(this.getView().getSelectionModel().getSelected().items);


### PR DESCRIPTION
Now, if you have only one entry in the devices grid and select a device from the list, the card is positioned only for the first time (the "selected" event is triggered). I added rowclick event handler. Now with any click on the device in devices grid, the map will show where the car is located.