### PR TITLE
Fix misleading displayed label

### DIFF
--- a/web/app/view/dialog/Server.js
+++ b/web/app/view/dialog/Server.js
@@ -47,7 +47,7 @@ Ext.define('Traccar.view.dialog.Server', {
                 xtype: 'unescapedTextField',
                 reference: 'mapUrlField',
                 name: 'mapUrl',
-                fieldLabel: Strings.mapCustom
+                fieldLabel: Strings.mapCustomLabel
             }, {
                 xtype: 'numberfield',
                 reference: 'latitude',

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -233,6 +233,7 @@
     "mapLayer": "Map Layer",
     "mapCustom": "Custom (XYZ)",
     "mapCustomArcgis": "Custom (ArcGIS)",
+    "mapCustomLabel": "Custom map",
     "mapCarto": "Carto Basemaps",
     "mapOsm": "Open Street Map",
     "mapBingKey": "Bing Maps Key",


### PR DESCRIPTION
I just noted that my PR [https://github.com/traccar/traccar-web/pull/749](https://github.com/traccar/traccar-web/pull/749), has introduced a misleading displayed label. No matter what map layer is selected, the label for the custom map URL field, always displays as `Custom (XYZ)`. Please, suggest the name you like for the key.
Now, I remember the reason why I created a new key `mapCustomXyz` for `Custom (XYZ)`, instead of reusing `mapCustom`. Of course, as you said, that change would have broken everyone's configuration.
Thanks.