### PR TITLE
Fix some translation problems in pt-br and pt

### DIFF
--- a/web/l10n/pt.json
+++ b/web/l10n/pt.json
@@ -424,9 +424,9 @@
     "categoryTrain": "Trem",
     "categoryTram": "Bonde",
     "categoryTrolleybus": "Ônibus Elétrico",
-    "categoryTruck": "Camião",
+    "categoryTruck": "Caminhão",
     "categoryVan": "Caravana",
-    "categoryScooter": "Scooter",
+    "categoryScooter": "Patinete Elétrico",
     "maintenanceStart": "Começar",
     "maintenancePeriod": "Período"
 }

--- a/web/l10n/pt_BR.json
+++ b/web/l10n/pt_BR.json
@@ -426,7 +426,7 @@
     "categoryTrolleybus": "Ônibus Elétrico",
     "categoryTruck": "Caminhão",
     "categoryVan": "Van",
-    "categoryScooter": "Lambreta",
+    "categoryScooter": "Patinete Elétrico",
     "maintenanceStart": "Começar",
     "maintenancePeriod": "Período"
 }


### PR DESCRIPTION
I have make a PR some months ago adding the Scooter category, as it rises popularity, but someone has made a PR changing the translation to something the icon doesn't represent.

It is a Eletric Scooter, as Grin, Yellow, Lime, Bird uses.
Scooter as "Patinete Elétrico":
![image](https://user-images.githubusercontent.com/6011385/65070912-e7798000-d963-11e9-80c5-7bffbcf6f804.png)

Not Scooter as a type of motorcycle with less motor power, as the meaning of Lambreta means.
Scooter as "Lambreta": 
![image](https://user-images.githubusercontent.com/6011385/65070977-10017a00-d964-11e9-913b-5a1c0051d22a.png)
