### PR TITLE
Add long./lat./zoom URI parameters to simple UI

### DIFF
--- a/web/simple/app.js
+++ b/web/simple/app.js
@@ -29,8 +29,12 @@ if (!Array.prototype.find) {
   });
 }
 
+var getQueryParameter = function(name) {
+	return (window.location.search.match('[?&]' + name + '=([^&]*)') || [])[1];
+};
+
 var url = window.location.protocol + '//' + window.location.host;
-var token = (window.location.search.match(/token=([^&#]+)/) || [])[1];
+var token = getQueryParameter('token');
 
 var style = function (label) {
     return new ol.style.Style({
@@ -98,10 +102,10 @@ ajax('GET', url + '/api/server', function(server) {
     ajax('GET', url + '/api/session?token=' + token, function(user) {
 
         map.getView().setCenter(ol.proj.fromLonLat([
-            user.longitude || server.longitude || 0.0,
-            user.latitude || server.latitude || 0.0
+            parseFloat(getQueryParameter('longitude')) || user.longitude || server.longitude || 0.0,
+            parseFloat(getQueryParameter('latitude')) || user.latitude || server.latitude || 0.0
         ]));
-        map.getView().setZoom(user.zoom || server.zoom || 2);
+        map.getView().setZoom(parseFloat(getQueryParameter('zoom')) || user.zoom || server.zoom || 2);
 
         ajax('GET', url + '/api/devices', function(devices) {
 


### PR DESCRIPTION
Instead of reading the longitude, latitude and zoom options from the
user / server configuration, one could use the new longitude=,
latitude= and zoom= URI parameters, in order to define the launch map
view. This is especially useful, in case you would like to embed
multiple maps with different views into e.g. another website.