### PR TITLE
Added tileSize attribute for OSM map style

### DIFF
--- a/modern/src/map/mapStyles.js
+++ b/modern/src/map/mapStyles.js
@@ -1,11 +1,11 @@
-export const styleCustom = (url, attribution, tileSize) => ({
+export const styleCustom = (url, attribution) => ({
   version: 8,
   sources: {
     osm: {
       type: 'raster',
       tiles: [url],
       attribution: attribution,
-      tileSize: tileSize,
+      tileSize: 256,
     },
   },
   glyphs: 'https://cdn.traccar.com/map/fonts/{fontstack}/{range}.pbf',
@@ -19,7 +19,6 @@ export const styleCustom = (url, attribution, tileSize) => ({
 export const styleOsm = () => styleCustom(
   'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
   '© <a target="_top" rel="noopener" href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-  256,
 );
 
 export const styleCarto = () => ({

--- a/modern/src/map/mapStyles.js
+++ b/modern/src/map/mapStyles.js
@@ -1,10 +1,11 @@
-export const styleCustom = (url, attribution) => ({
+export const styleCustom = (url, attribution, tileSize) => ({
   version: 8,
   sources: {
     osm: {
       type: 'raster',
       tiles: [url],
       attribution: attribution,
+      tileSize: tileSize,
     },
   },
   glyphs: 'https://cdn.traccar.com/map/fonts/{fontstack}/{range}.pbf',
@@ -18,6 +19,7 @@ export const styleCustom = (url, attribution) => ({
 export const styleOsm = () => styleCustom(
   'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
   '© <a target="_top" rel="noopener" href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  256,
 );
 
 export const styleCarto = () => ({


### PR DESCRIPTION
In the style object for OSM, tileSize attribute is not specified, and MapboxGL defaults to 512x512(which should be 256x256 for OSM) and this causes a blurry map as mentioned at https://github.com/traccar/traccar-web/issues/827. This PR improves map quality by fixing it and eliminates one of the two reasons that causes blurry maps for OSM.  The other reason is related to non-integer zoom levels for raster tiles and requires a more complex solution.