### PR TITLE
Fix Blurry Raster Maps

### DIFF
--- a/modern/src/map/Map.js
+++ b/modern/src/map/Map.js
@@ -42,18 +42,7 @@ const onIdle = function () {
   }
 };
 
-const setAllowedZoomLevels = map => {
-  if (Object.values(map.getStyle().sources).some(e => e.type === 'raster')) {
-    map.scrollZoom.setWheelZoomRate(1);
-    map.on('idle', onIdle);
-  } else {
-    map.scrollZoom.setWheelZoomRate(1/450);
-    map.off('idle', onIdle);
-  }
-};
-
 const initMap = async () => {
-  setAllowedZoomLevels(map);
   const background = await loadImage('images/background.svg');
   await Promise.all(deviceCategories.map(async category => {
     if (!map.hasImage(category)) {
@@ -110,6 +99,17 @@ const Map = ({ children }) => {
       removeReadyListener(listener);
     };
   }, []);
+
+  useEffect(() => {
+    if (mapReady && Object.values(map.getStyle().sources).some(e => e.type === 'raster')) {
+        map.scrollZoom.setWheelZoomRate(1);
+        map.on('idle', onIdle);
+      }
+    return () => {
+      map.scrollZoom.setWheelZoomRate(1/450);
+      map.off('idle', onIdle);
+    }
+  }, [mapReady]);
 
   useLayoutEffect(() => {
     const currentEl = containerEl.current;

--- a/modern/src/map/Map.js
+++ b/modern/src/map/Map.js
@@ -42,10 +42,8 @@ const onIdle = function () {
   }
 };
 
-const isRasterMap = map => Object.values(map.getStyle().sources).some(e => e.type === 'raster');
-
 const setAllowedZoomLevels = map => {
-  if(isRasterMap(map)) {
+  if (Object.values(map.getStyle().sources).some(e => e.type === 'raster')) {
     map.scrollZoom.setWheelZoomRate(1);
     map.on('idle', onIdle);
   } else {

--- a/modern/src/map/Map.js
+++ b/modern/src/map/Map.js
@@ -35,7 +35,27 @@ const updateReadyValue = value => {
   readyListeners.forEach(listener => listener(value));
 };
 
+const onIdle = function () {
+  const zoom = Math.round(map.getZoom())
+  if (zoom !== map.getZoom()) {
+    map.zoomTo(zoom)
+  }
+};
+
+const isRasterMap = map => Object.values(map.getStyle().sources).some(e => e.type === 'raster');
+
+const setAllowedZoomLevels = map => {
+  if(isRasterMap(map)) {
+    map.scrollZoom.setWheelZoomRate(1);
+    map.on('idle', onIdle);
+  } else {
+    map.scrollZoom.setWheelZoomRate(1/450);
+    map.off('idle', onIdle);
+  }
+};
+
 const initMap = async () => {
+  setAllowedZoomLevels(map);
   const background = await loadImage('images/background.svg');
   await Promise.all(deviceCategories.map(async category => {
     if (!map.hasImage(category)) {

--- a/modern/src/map/Map.js
+++ b/modern/src/map/Map.js
@@ -35,13 +35,6 @@ const updateReadyValue = value => {
   readyListeners.forEach(listener => listener(value));
 };
 
-const onIdle = function () {
-  const zoom = Math.round(map.getZoom())
-  if (zoom !== map.getZoom()) {
-    map.zoomTo(zoom)
-  }
-};
-
 const initMap = async () => {
   const background = await loadImage('images/background.svg');
   await Promise.all(deviceCategories.map(async category => {
@@ -102,12 +95,18 @@ const Map = ({ children }) => {
 
   useEffect(() => {
     if (mapReady && Object.values(map.getStyle().sources).some(e => e.type === 'raster')) {
-        map.scrollZoom.setWheelZoomRate(1);
-        map.on('idle', onIdle);
+      const onIdle = function () {
+        const zoom = Math.round(map.getZoom());
+        if (zoom !== map.getZoom()) {
+          map.zoomTo(zoom);
+        }
+      };
+      map.scrollZoom.setWheelZoomRate(1);
+      map.on('idle', onIdle);
+      return () => {
+        map.scrollZoom.setWheelZoomRate(1/450);
+        map.off('idle', onIdle);
       }
-    return () => {
-      map.scrollZoom.setWheelZoomRate(1/450);
-      map.off('idle', onIdle);
     }
   }, [mapReady]);
 


### PR DESCRIPTION
This PR fixes https://github.com/traccar/traccar-web/issues/827 by limiting zoom levels for raster maps to integers. 

How it works:
- If the current map is a raster map, set wheelZoomRate to 1. This way every scroll wheel tick increments or decrements zoom level by 1. 
- An event listener is added to the map which will listen for "idle" event(which is fired when the map is fully rendered after an action), then sets the zoom level to nearest integer value of current level. This handles zoom changes by mobile devices, touchpads etc.
- If the current map is not a raster map, set wheelZoomRate to default value, remove the event listener.