### PR TITLE
Fix issue with event time not being displayed in event report

### DIFF
--- a/web/app/view/Events.js
+++ b/web/app/view/Events.js
@@ -111,7 +111,7 @@ Ext.define('Traccar.view.Events', {
         }, {
             text: Strings.positionFixTime,
             dataIndex: 'eventTime',
-            renderer: Traccar.AttributeFormatter.getFormatter('lastUpdate')
+            renderer: Traccar.AttributeFormatter.getFormatter('eventTime')
         }]
     }
 });


### PR DESCRIPTION
Without this change the Time column is always empty in the events report view.
The change matches what is in ReportController.js