### PR TITLE
Added device attribute allowForwarding

### DIFF
--- a/web/app/store/DeviceAttributes.js
+++ b/web/app/store/DeviceAttributes.js
@@ -48,5 +48,9 @@ Ext.define('Traccar.store.DeviceAttributes', {
         valueType: 'number',
         allowDecimals: false,
         minValue: 1
+    }, {
+        key: 'allowForwarding',
+        name: Strings.attributeAllowForwarding,
+        valueType: 'boolean'
     }]
 });

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -90,6 +90,7 @@
     "attributeDevicePassword": "Device Password",
     "attributeDeviceInactivityStart": "Device Inactivity Start",
     "attributeDeviceInactivityPeriod": "Device Inactivity Period",
+    "attributeAllowForwarding": "Allow Forwarding",
     "attributeProcessingCopyAttributes": "Processing: Copy Attributes",
     "attributeColor": "Color",
     "attributeWebLiveRouteLength": "Web: Live Route Length",


### PR DESCRIPTION
With this change a user can select per device if the data should be forwarded or not.
In our situation we have a lot of trackers but only the data for a few needs to be forwarded.