### PR TITLE
fix: Fab not shown on mobile device

### DIFF
--- a/modern/src/settings/components/CollectionFab.js
+++ b/modern/src/settings/components/CollectionFab.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
     bottom: theme.spacing(2),
     right: theme.spacing(2),
     [theme.breakpoints.down('md')]: {
-      bottom: theme.dimensions.bottomBarHeight + theme.spacing(2),
+      bottom: parseInt(dimensions.bottomBarHeight, 10) + parseInt(theme.spacing(2), 10),
     },
   },
 }));


### PR DESCRIPTION
Hi Anton,
I hope you're doing fine, the fix is about a bug on Fab Button on Mobile devices, the existing code was concatenating string values and the output was  `bottom:5616`, I just parse strings to numbers to get the correct value for bottom css attribute.