### PR TITLE
Fix: Fab Button now shown on mobile devices

### DIFF
--- a/modern/src/settings/components/CollectionFab.js
+++ b/modern/src/settings/components/CollectionFab.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
     bottom: theme.spacing(2),
     right: theme.spacing(2),
     [theme.breakpoints.down('md')]: {
-      bottom: parseInt(theme.dimensions.bottomBarHeight, 10) + parseInt(theme.spacing(2), 10),
+      bottom: `calc(${theme.dimensions.bottomBarHeight}px + ${theme.spacing(2)})`,
     },
   },
 }));

--- a/modern/src/settings/components/CollectionFab.js
+++ b/modern/src/settings/components/CollectionFab.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
     bottom: theme.spacing(2),
     right: theme.spacing(2),
     [theme.breakpoints.down('md')]: {
-      bottom: parseInt(dimensions.bottomBarHeight, 10) + parseInt(theme.spacing(2), 10),
+      bottom: parseInt(theme.dimensions.bottomBarHeight, 10) + parseInt(theme.spacing(2), 10),
     },
   },
 }));

--- a/modern/src/settings/components/CollectionFab.js
+++ b/modern/src/settings/components/CollectionFab.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
     bottom: theme.spacing(2),
     right: theme.spacing(2),
     [theme.breakpoints.down('md')]: {
-      bottom: theme.dimensions.bottomBarHeight + theme.spacing(2),
+      bottom: parseInt(dimensions.bottomBarHeight, 10) + parseInt(theme.spacing(2), 10),
     },
   },
 }));


### PR DESCRIPTION
Hi Anton, 
I hope you're doing fine, the fix is about Fab button not shown on mobile Device, the cause was that the existing code was concatening string values, and the output for Bottom attribute css was `bottom: 5616` instead of `bottom:72`, I parsed the string to become Int.