### PR TITLE
Feature request, Parking timer on traccar-web

### DIFF
--- a/src/org/traccar/web/client/view/MapView.java
+++ b/src/org/traccar/web/client/view/MapView.java
@@ -26,9 +26,6 @@ import org.gwtopenmaps.openlayers.client.Style;
 import org.gwtopenmaps.openlayers.client.control.LayerSwitcher;
 import org.gwtopenmaps.openlayers.client.control.ScaleLine;
 import org.gwtopenmaps.openlayers.client.geometry.Point;
-import org.gwtopenmaps.openlayers.client.layer.Bing;
-import org.gwtopenmaps.openlayers.client.layer.BingOptions;
-import org.gwtopenmaps.openlayers.client.layer.BingType;
 import org.gwtopenmaps.openlayers.client.layer.GoogleV3;
 import org.gwtopenmaps.openlayers.client.layer.GoogleV3MapType;
 import org.gwtopenmaps.openlayers.client.layer.GoogleV3Options;
@@ -112,11 +109,6 @@ public class MapView {
         gTerrainOptions.setNumZoomLevels(16);
         gTerrainOptions.setType(GoogleV3MapType.G_TERRAIN_MAP);
         map.addLayer(new GoogleV3("Google Terrain", gTerrainOptions));
-
-        final String bingKey = "AseEs0DLJhLlTNoxbNXu7DGsnnH4UoWuGue7-irwKkE3fffaClwc9q_Mr6AyHY8F";
-        map.addLayer(new Bing(new BingOptions("Bing Road", bingKey, BingType.ROAD)));
-        map.addLayer(new Bing(new BingOptions("Bing Hybrid", bingKey, BingType.HYBRID)));
-        map.addLayer(new Bing(new BingOptions("Bing Aerial", bingKey, BingType.AERIAL)));
     }
 
     public MapView(MapHandler mapHandler) {


### PR DESCRIPTION
This is my very first feature request on Github, sorry if it is on wrong place?

Is it possible to show the Parking Time directly on the detailscreen?
There is a parameter "motion" behind the green button, maybe this can be used to calculate the parking minutes/hours?

e.g. No Motion since: "xx:xx:xx" minutes

My intention for this request: 
I´, delivering on a route from 9 am to 3 pm with round about 10 Stops a day, every 30-45 minutes to my customers with exactly defind appointments on time, sometimes the appointment to be at the customer is not possible because of traffic or other circumstances so the next customer knows we are little late.

