### PR TITLE
Hide password field when OpenID forced

### DIFF
--- a/modern/src/settings/UserPage.js
+++ b/modern/src/settings/UserPage.js
@@ -55,6 +55,7 @@ const UserPage = () => {
 
   const currentUser = useSelector((state) => state.session.user);
   const registrationEnabled = useSelector((state) => state.session.server.registration);
+  const openIdForced = useSelector((state) => state.session.server.openIdForce);
 
   const mapStyles = useMapStyles();
   const commonUserAttributes = useCommonUserAttributes(t);
@@ -135,11 +136,13 @@ const UserPage = () => {
                 label={t('userEmail')}
                 disabled={fixedEmail}
               />
-              <TextField
-                type="password"
-                onChange={(event) => setItem({ ...item, password: event.target.value })}
-                label={t('userPassword')}
-              />
+              {!openIdForced && (
+                <TextField
+                  type="password"
+                  onChange={(event) => setItem({ ...item, password: event.target.value })}
+                  label={t('userPassword')}
+                />
+              )}
             </AccordionDetails>
           </Accordion>
           <Accordion>


### PR DESCRIPTION
As discussed on traccar/traccar PR.

Is it worth doing this for LDAP too? I didn't add it now because it doesnt look like the /api/server endpoint reports it.