### PR TITLE
RouteReportPage.js added table pagination

### DIFF
--- a/modern/package.json
+++ b/modern/package.json
@@ -66,6 +66,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-react": "^7.32.2",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "react-virtuoso": "^4.3.10"
   }
 }

--- a/modern/package.json
+++ b/modern/package.json
@@ -66,7 +66,6 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-react": "^7.32.2",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "react-virtuoso": "^4.3.10"
+    "eslint-plugin-react-hooks": "^4.6.0"
   }
 }

--- a/modern/src/reports/RouteReportPage.js
+++ b/modern/src/reports/RouteReportPage.js
@@ -176,15 +176,18 @@ const RouteReportPage = () => {
               )) : (<TableShimmer columns={columns.length + 2} startAction />)}
             </TableBody>
           </Table>
-          <TablePagination
-            rowsPerPageOptions={[100, 150, 200]}
-            component="div"
-            count={items.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={handleChangePage}
-            onRowsPerPageChange={handleChangeRowsPerPage}
-          />
+          {items.length > 100 && (
+            <TablePagination
+              sx={{ position: 'sticky', bottom: 0, left: 0, backgroundColor: 'Background' }}
+              rowsPerPageOptions={[100, 150, 200]}
+              component="div"
+              count={items.length}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onPageChange={handleChangePage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          )}
         </div>
       </div>
     </PageLayout>

--- a/modern/src/reports/RouteReportPage.js
+++ b/modern/src/reports/RouteReportPage.js
@@ -38,19 +38,10 @@ const RouteReportPage = () => {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
-  //
+
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(100);
+  const [itemsPerPage, setItemsPerPage] = useState(50);
 
-  const handleChangePage = (event, newPage) => {
-    setPage(newPage);
-  };
-
-  const handleChangeRowsPerPage = (event) => {
-    setRowsPerPage(+event.target.value);
-    setPage(0);
-  };
-  //
   const onMapPointClick = useCallback((positionId) => {
     setSelectedItem(items.find((it) => it.id === positionId));
   }, [items, setSelectedItem]);
@@ -149,7 +140,7 @@ const RouteReportPage = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {!loading ? items.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((item) => (
+              {!loading ? items.slice(page * itemsPerPage, page * itemsPerPage + itemsPerPage).map((item) => (
                 <TableRow key={item.id}>
                   <TableCell className={classes.columnAction} padding="none">
                     {selectedItem === item ? (
@@ -176,16 +167,21 @@ const RouteReportPage = () => {
               )) : (<TableShimmer columns={columns.length + 2} startAction />)}
             </TableBody>
           </Table>
-          {items.length > 100 && (
+          {items.length > 1000 && (
             <TablePagination
-              sx={{ position: 'sticky', bottom: 0, left: 0, backgroundColor: 'Background' }}
-              rowsPerPageOptions={[100, 150, 200]}
+              className={classes.pagination}
+              rowsPerPageOptions={[50, 100, 200, 500]}
               component="div"
               count={items.length}
-              rowsPerPage={rowsPerPage}
+              rowsPerPage={itemsPerPage}
               page={page}
-              onPageChange={handleChangePage}
-              onRowsPerPageChange={handleChangeRowsPerPage}
+              onPageChange={(event, page) => setPage(page)}
+              onRowsPerPageChange={
+                (event) => {
+                  setItemsPerPage(Number(event.target.value));
+                  setPage(0);
+                }
+              }
             />
           )}
         </div>

--- a/modern/src/reports/RouteReportPage.js
+++ b/modern/src/reports/RouteReportPage.js
@@ -2,13 +2,14 @@ import React, { Fragment, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
-  IconButton, Table, TableBody, TableCell, TableHead, TableRow,
+  IconButton, Skeleton,
 } from '@mui/material';
 import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 import LocationSearchingIcon from '@mui/icons-material/LocationSearching';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { TableVirtuoso } from 'react-virtuoso';
-import TableContainer from '@mui/material/TableContainer';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { FixedSizeGrid } from 'react-window';
 import ReportFilter from './components/ReportFilter';
 import { useTranslation } from '../common/components/LocalizationProvider';
 import PageLayout from '../common/components/PageLayout';
@@ -26,22 +27,14 @@ import MapCamera from '../map/MapCamera';
 import MapGeofence from '../map/MapGeofence';
 import scheduleReport from './common/scheduleReport';
 
-const VirtuosoTableComponents = {
-  Scroller: React.forwardRef((props, ref) => (
-    <TableContainer {...props} ref={ref} />
-  )),
-  Table: (props) => (
-    <Table {...props} />
-  ),
-  TableHead,
-  TableRow: ({ item: _item, ...props }) => <TableRow {...props} />,
-  TableBody: React.forwardRef((props, ref) => <TableBody {...props} ref={ref} />),
-};
-
 const RouteReportPage = () => {
   const navigate = useNavigate();
   const classes = useReportStyles();
   const t = useTranslation();
+  const theme = useTheme();
+
+  const phone = useMediaQuery(theme.breakpoints.down('md'));
+  const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
   const positionAttributes = usePositionAttributes(t);
 
@@ -109,48 +102,6 @@ const RouteReportPage = () => {
     }
   });
 
-  const fixedHeaderContent = () => (
-    <TableRow style={{ backgroundColor: 'white' }}>
-      <TableCell className={classes.columnAction} />
-      <TableCell>{t('sharedDevice')}</TableCell>
-      {columns.map((key) => (
-        <TableCell
-          key={key}
-          variant="head"
-          align={key.numeric || false ? 'right' : 'left'}
-        >
-          {positionAttributes[key]?.name || key}
-        </TableCell>
-      ))}
-    </TableRow>
-  );
-
-  const rowContent = (_index, item) => (
-    <>
-      <TableCell className={classes.columnAction} padding="none">
-        {selectedItem === item ? (
-          <IconButton size="small" onClick={() => setSelectedItem(null)}>
-            <GpsFixedIcon fontSize="small" />
-          </IconButton>
-        ) : (
-          <IconButton size="small" onClick={() => setSelectedItem(item)}>
-            <LocationSearchingIcon fontSize="small" />
-          </IconButton>
-        )}
-      </TableCell>
-      <TableCell>{devices[item.deviceId].name}</TableCell>
-      {columns.map((key) => (
-        <TableCell key={key}>
-          <PositionValue
-            position={item}
-            property={item.hasOwnProperty(key) ? key : null}
-            attribute={item.hasOwnProperty(key) ? null : key}
-          />
-        </TableCell>
-      ))}
-    </>
-  );
-
   return (
     <PageLayout menu={<ReportsMenu />} breadcrumbs={['reportTitle', 'reportRoute']}>
       <div className={classes.container}>
@@ -172,7 +123,7 @@ const RouteReportPage = () => {
             <MapCamera positions={items} />
           </div>
         )}
-        <div>
+        <div className={classes.containerMain} style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
           <div className={classes.header}>
             <ReportFilter handleSubmit={handleSubmit} handleSchedule={handleSchedule} multiDevice>
               <ColumnSelect
@@ -184,15 +135,95 @@ const RouteReportPage = () => {
               />
             </ReportFilter>
           </div>
+          <div style={{ flex: 1 }}>
+            <AutoSizer>
+              {({ height, width }) => (
+                <FixedSizeGrid
+                  height={height}
+                  width={width}
+                  columnCount={columns.length + 2}
+                  columnWidth={(columns.length + 2) * (width * (phone ? 0.26 : desktop ? 0.1 : 0.18)) >= width ?
+                    width * (phone ? 0.26 : desktop ? 0.1 : 0.18) : width / (columns.length + 2)}
+                  rowCount={items.length > 0 ? items.length : 5}
+                  rowHeight={52}
+                  overscanRowCount={20}
+                >
+                  {({ columnIndex, rowIndex, style }) => {
+                    const item = items[rowIndex];
+                    const columnKey = columns[columnIndex - 2];
+                    return (
+                      rowIndex === 0 ?
+                        columnIndex === 0 ?
+                          (
+                            <div className={classes.cellStyle} style={style} />
+                          )
+                          :
+                          columnIndex === 1 ?
+                            (
+                              <div className={classes.cellStyle} style={style}>
+                                <b>{t('sharedDevice')}</b>
+                              </div>
+                            ) :
+                            columnIndex < columns.length + 2 ?
+                              (
+                                <div className={classes.cellStyle} style={style}>
+                                  <b>{positionAttributes[columnKey]?.name || columnKey}</b>
+                                </div>
+                              )
+                              :
+                              null
+                        :
+                        !loading ?
+                          item ?
+                            columnIndex === 0 ?
+                              (
+                                <div className={`${classes.cellStyle} ${classes.columnAction}`} style={style}>
+                                  {selectedItem === item ?
+                                    (
+                                      <IconButton size="small" onClick={() => setSelectedItem(null)}>
+                                        <GpsFixedIcon fontSize="small" />
+                                      </IconButton>
+                                    )
+                                    :
+                                    (
+                                      <IconButton size="small" onClick={() => setSelectedItem(item)}>
+                                        <LocationSearchingIcon fontSize="small" />
+                                      </IconButton>
+                                    )}
+                                </div>
+                              )
+                              :
+                              columnIndex === 1 ?
+                                (
+                                  <div className={classes.cellStyle} style={style}>
+                                    {devices[item.deviceId].name}
+                                  </div>
+                                )
+                                :
+                                (
+                                  <div className={classes.cellStyle} style={style}>
+                                    <PositionValue
+                                      position={item}
+                                      property={item.hasOwnProperty(columnKey) ? columnKey : null}
+                                      attribute={item.hasOwnProperty(columnKey) ? null : columnKey}
+                                    />
+                                  </div>
+                                )
+                            :
+                            null
+                          :
+                          (
+                            <div className={classes.cellStyle} style={style}>
+                              <Skeleton variant="text" width={width / (columns.length * 1.5)} />
+                            </div>
+                          )
+                    );
+                  }}
+                </FixedSizeGrid>
+              )}
+            </AutoSizer>
+          </div>
         </div>
-        {!loading && (
-          <TableVirtuoso
-            data={items}
-            components={VirtuosoTableComponents}
-            fixedHeaderContent={fixedHeaderContent}
-            itemContent={rowContent}
-          />
-        )}
       </div>
     </PageLayout>
   );

--- a/modern/src/reports/RouteReportPage.js
+++ b/modern/src/reports/RouteReportPage.js
@@ -140,7 +140,7 @@ const RouteReportPage = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {!loading ? items.slice(page * itemsPerPage, page * itemsPerPage + itemsPerPage).map((item) => (
+              {!loading ? (items.length > 1000 ? items.slice(page * itemsPerPage, page * itemsPerPage + itemsPerPage) : items).map((item) => (
                 <TableRow key={item.id}>
                   <TableCell className={classes.columnAction} padding="none">
                     {selectedItem === item ? (

--- a/modern/src/reports/RouteReportPage.js
+++ b/modern/src/reports/RouteReportPage.js
@@ -2,7 +2,7 @@ import React, { Fragment, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
-  IconButton, Table, TableBody, TableCell, TableHead, TableRow,
+  IconButton, Table, TableBody, TableCell, TableHead, TablePagination, TableRow,
 } from '@mui/material';
 import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 import LocationSearchingIcon from '@mui/icons-material/LocationSearching';
@@ -38,7 +38,19 @@ const RouteReportPage = () => {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
+  //
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(100);
 
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(+event.target.value);
+    setPage(0);
+  };
+  //
   const onMapPointClick = useCallback((positionId) => {
     setSelectedItem(items.find((it) => it.id === positionId));
   }, [items, setSelectedItem]);
@@ -137,7 +149,7 @@ const RouteReportPage = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {!loading ? items.slice(0, 4000).map((item) => (
+              {!loading ? items.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((item) => (
                 <TableRow key={item.id}>
                   <TableCell className={classes.columnAction} padding="none">
                     {selectedItem === item ? (
@@ -164,6 +176,15 @@ const RouteReportPage = () => {
               )) : (<TableShimmer columns={columns.length + 2} startAction />)}
             </TableBody>
           </Table>
+          <TablePagination
+            rowsPerPageOptions={[100, 150, 200]}
+            component="div"
+            count={items.length}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
         </div>
       </div>
     </PageLayout>

--- a/modern/src/reports/common/useReportStyles.js
+++ b/modern/src/reports/common/useReportStyles.js
@@ -46,4 +46,14 @@ export default makeStyles((theme) => ({
     flexGrow: 1,
     overflow: 'hidden',
   },
+  pagination: {
+    position: 'static',
+    bottom: 0,
+    '& .MuiTablePagination-spacer': {
+      display: 'none',
+    },
+    '& .MuiTablePagination-toolbar': {
+      justifyContent: 'center',
+    },
+  },
 }));

--- a/modern/src/reports/common/useReportStyles.js
+++ b/modern/src/reports/common/useReportStyles.js
@@ -17,6 +17,7 @@ export default makeStyles((theme) => ({
     position: 'sticky',
     left: 0,
     display: 'flex',
+    height: '100%',
     flexDirection: 'column',
     alignItems: 'stretch',
   },
@@ -45,15 +46,5 @@ export default makeStyles((theme) => ({
   chart: {
     flexGrow: 1,
     overflow: 'hidden',
-  },
-  pagination: {
-    position: 'static',
-    bottom: 0,
-    '& .MuiTablePagination-spacer': {
-      display: 'none',
-    },
-    '& .MuiTablePagination-toolbar': {
-      justifyContent: 'center',
-    },
   },
 }));

--- a/modern/src/reports/common/useReportStyles.js
+++ b/modern/src/reports/common/useReportStyles.js
@@ -17,7 +17,6 @@ export default makeStyles((theme) => ({
     position: 'sticky',
     left: 0,
     display: 'flex',
-    height: '100%',
     flexDirection: 'column',
     alignItems: 'stretch',
   },
@@ -46,5 +45,11 @@ export default makeStyles((theme) => ({
   chart: {
     flexGrow: 1,
     overflow: 'hidden',
+  },
+  cellStyle: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: '5px',
+    borderBottom: '1px solid lightgrey',
   },
 }));


### PR DESCRIPTION
[fix] Browser slowdown after executing a Route report with large number of records; 
The 4000 row preview slice limit is removed.

Forum [Discussion](https://www.traccar.org/forums/topic/question-about-adding-pagination-for-report-visualization/)
Library used: [Material-UI table pagination](https://mui.com/material-ui/react-table/#sticky-header)

This is an initial version using the MUI example for table pagination. 
Additional features/behavior may be added after discussion and approval.