### PR TITLE
Sync old Position Attribute formatters to Modern

### DIFF
--- a/modern/src/common/components/PositionValue.js
+++ b/modern/src/common/components/PositionValue.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import {
-  formatAlarm, formatAltitude, formatBoolean, formatCoordinate, formatCourse, formatDistance, formatNumber, formatNumericHours, formatPercentage, formatSpeed, formatTime, formatTemperature,
+  formatAlarm, formatAltitude, formatBoolean, formatCoordinate, formatCourse, formatDistance, formatNumber, formatNumericHours, formatPercentage, formatSpeed, formatTime, formatTemperature, formatVoltage,
 } from '../util/formatter';
 import { useAttributePreference, usePreference } from '../util/preferences';
 import { useTranslation } from './LocalizationProvider';
@@ -38,11 +38,15 @@ const PositionValue = ({ position, property, attribute }) => {
       case 'longitude':
         return formatCoordinate('longitude', value, coordinateFormat);
       case 'speed':
+      case 'obdSpeed':
         return formatSpeed(value, speedUnit, t);
       case 'course':
         return formatCourse(value);
       case 'altitude':
         return formatAltitude(value, altitudeUnit, t);
+      case 'power':
+      case 'battery':
+        return formatVoltage(value, t);
       case 'batteryLevel':
         return value != null ? formatPercentage(value, t) : '';
       case 'coolantTemp':
@@ -50,6 +54,9 @@ const PositionValue = ({ position, property, attribute }) => {
       case 'alarm':
         return formatAlarm(value, t);
       case 'odometer':
+      case 'serviceOdometer':
+      case 'tripOdometer':
+      case 'obdOdometer':
       case 'distance':
       case 'totalDistance':
         return value != null ? formatDistance(value, distanceUnit, t) : '';

--- a/modern/src/common/components/PositionValue.js
+++ b/modern/src/common/components/PositionValue.js
@@ -18,7 +18,6 @@ import {
   formatVoltage,
   formatVolume,
   formatConsumption,
-  formatDriverUniqueId,
 } from '../util/formatter';
 import { useAttributePreference, usePreference } from '../util/preferences';
 import { useTranslation } from './LocalizationProvider';
@@ -82,8 +81,6 @@ const PositionValue = ({ position, property, attribute }) => {
         return value != null ? formatDistance(value, distanceUnit, t) : '';
       case 'hours':
         return value != null ? formatNumericHours(value, t) : '';
-      case 'driverUniqueId':
-        return value != null ? formatDriverUniqueId(value) : '';
       default:
         if (typeof value === 'number') {
           return formatNumber(value);

--- a/modern/src/common/components/PositionValue.js
+++ b/modern/src/common/components/PositionValue.js
@@ -3,7 +3,21 @@ import { useSelector } from 'react-redux';
 import { Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import {
-  formatAlarm, formatAltitude, formatBoolean, formatCoordinate, formatCourse, formatDistance, formatNumber, formatNumericHours, formatPercentage, formatSpeed, formatTime, formatTemperature, formatVoltage,
+  formatAlarm,
+  formatAltitude,
+  formatBoolean,
+  formatCoordinate,
+  formatCourse,
+  formatDistance,
+  formatNumber,
+  formatNumericHours,
+  formatPercentage,
+  formatSpeed,
+  formatTime,
+  formatTemperature,
+  formatVoltage,
+  formatVolume,
+  formatConsumption,
 } from '../util/formatter';
 import { useAttributePreference, usePreference } from '../util/preferences';
 import { useTranslation } from './LocalizationProvider';
@@ -24,6 +38,7 @@ const PositionValue = ({ position, property, attribute }) => {
   const distanceUnit = useAttributePreference('distanceUnit');
   const altitudeUnit = useAttributePreference('altitudeUnit');
   const speedUnit = useAttributePreference('speedUnit');
+  const volumeUnit = useAttributePreference('volumeUnit');
   const coordinateFormat = usePreference('coordinateFormat');
   const hours12 = usePreference('twelveHourFormat');
 
@@ -39,7 +54,7 @@ const PositionValue = ({ position, property, attribute }) => {
         return formatCoordinate('longitude', value, coordinateFormat);
       case 'speed':
       case 'obdSpeed':
-        return formatSpeed(value, speedUnit, t);
+        return value != null ? formatSpeed(value, speedUnit, t) : '';
       case 'course':
         return formatCourse(value);
       case 'altitude':
@@ -49,6 +64,10 @@ const PositionValue = ({ position, property, attribute }) => {
         return formatVoltage(value, t);
       case 'batteryLevel':
         return value != null ? formatPercentage(value, t) : '';
+      case 'volume':
+        return value != null ? formatVolume(value, volumeUnit, t) : '';
+      case 'fuelConsumption':
+        return value != null ? formatConsumption(value, t) : '';
       case 'coolantTemp':
         return formatTemperature(value);
       case 'alarm':

--- a/modern/src/common/components/PositionValue.js
+++ b/modern/src/common/components/PositionValue.js
@@ -18,6 +18,7 @@ import {
   formatVoltage,
   formatVolume,
   formatConsumption,
+  formatDriverUniqueId,
 } from '../util/formatter';
 import { useAttributePreference, usePreference } from '../util/preferences';
 import { useTranslation } from './LocalizationProvider';
@@ -81,6 +82,8 @@ const PositionValue = ({ position, property, attribute }) => {
         return value != null ? formatDistance(value, distanceUnit, t) : '';
       case 'hours':
         return value != null ? formatNumericHours(value, t) : '';
+      case 'driverUniqueId':
+        return value != null ? formatDriverUniqueId(value) : '';
       default:
         if (typeof value === 'number') {
           return formatNumber(value);

--- a/modern/src/common/util/formatter.js
+++ b/modern/src/common/util/formatter.js
@@ -21,6 +21,8 @@ export const formatTemperature = (value) => `${value}°C`;
 
 export const formatVoltage = (value, t) => `${value} ${t('sharedVoltAbbreviation')}`;
 
+export const formatConsumption = (value, t) => `${value} ${t('sharedLiterPerHourAbbreviation')}`;
+
 export const formatTime = (value, format, hours12) => {
   if (value) {
     const m = moment(value);

--- a/modern/src/common/util/formatter.js
+++ b/modern/src/common/util/formatter.js
@@ -19,6 +19,8 @@ export const formatPercentage = (value) => `${value}%`;
 
 export const formatTemperature = (value) => `${value}°C`;
 
+export const formatVoltage = (value, t) => `${value} ${t('sharedVoltAbbreviation')}`;
+
 export const formatTime = (value, format, hours12) => {
   if (value) {
     const m = moment(value);

--- a/modern/src/common/util/formatter.js
+++ b/modern/src/common/util/formatter.js
@@ -1,4 +1,3 @@
-import { useSelector } from 'react-redux';
 import moment from 'moment';
 import {
   altitudeFromMeters,
@@ -67,16 +66,6 @@ export const formatNumericHours = (value, t) => {
   const hours = Math.floor(value / 3600000);
   const minutes = Math.floor((value % 3600000) / 60000);
   return `${hours} ${t('sharedHourAbbreviation')} ${minutes} ${t('sharedMinuteAbbreviation')}`;
-};
-
-export const formatDriverUniqueId = (value) => {
-  const drivers = useSelector((state) => state.drivers.items);
-  let driverId = `${value}`;
-  const storedDriver = Object.values(drivers).find((d) => d.uniqueId === driverId);
-  if (storedDriver) {
-    driverId += ` (${storedDriver.name})`;
-  }
-  return driverId;
 };
 
 export const formatCoordinate = (key, value, unit) => {

--- a/modern/src/common/util/formatter.js
+++ b/modern/src/common/util/formatter.js
@@ -1,3 +1,4 @@
+import { useSelector } from 'react-redux';
 import moment from 'moment';
 import {
   altitudeFromMeters,
@@ -66,6 +67,16 @@ export const formatNumericHours = (value, t) => {
   const hours = Math.floor(value / 3600000);
   const minutes = Math.floor((value % 3600000) / 60000);
   return `${hours} ${t('sharedHourAbbreviation')} ${minutes} ${t('sharedMinuteAbbreviation')}`;
+};
+
+export const formatDriverUniqueId = (value) => {
+  const drivers = useSelector((state) => state.drivers.items);
+  let driverId = `${value}`;
+  const storedDriver = Object.values(drivers).find((d) => d.uniqueId === driverId);
+  if (storedDriver) {
+    driverId += ` (${storedDriver.name})`;
+  }
+  return driverId;
 };
 
 export const formatCoordinate = (key, value, unit) => {


### PR DESCRIPTION
Hi,

this synces how the PositionAttribute formatting is done on the Modern interface, so that it matches the old interface. 
I extended the attributes which get formatted with speed and distance formatter, added voltage, driver unique id, consumption and volume.