### PR TITLE
StatusCard on mobile screens hides the device on the map

### DIFF
--- a/modern/src/common/components/StatusCard.js
+++ b/modern/src/common/components/StatusCard.js
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme) => ({
   content: {
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
-    'max-height': '40vh',
+    maxHeight: theme.dimensions.cardContentMaxHeight,
     overflow: 'scroll',
   },
   negative: {

--- a/modern/src/common/components/StatusCard.js
+++ b/modern/src/common/components/StatusCard.js
@@ -58,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
     'max-height': '40vh',
-    overflow: 'hidden',
+    overflow: 'scroll',
   },
   negative: {
     color: theme.palette.colors.negative,

--- a/modern/src/common/components/StatusCard.js
+++ b/modern/src/common/components/StatusCard.js
@@ -57,6 +57,8 @@ const useStyles = makeStyles((theme) => ({
   content: {
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
+    'max-height': '40vh',
+    overflow: 'hidden',
   },
   negative: {
     color: theme.palette.colors.negative,

--- a/modern/src/common/theme/dimensions.js
+++ b/modern/src/common/theme/dimensions.js
@@ -10,4 +10,5 @@ export default {
   popupMapOffset: 300,
   popupMaxWidth: 288,
   popupImageHeight: 144,
+  cardContentMaxHeight: '40vh',
 };


### PR DESCRIPTION
before:
![traccar fleetmap io_(iPhone SE) (1)](https://github.com/traccar/traccar-web/assets/31902485/84e4b17f-88cb-4132-9df4-c2fcfc54168e)

after:
![localhost_3000_(iPhone SE)](https://github.com/traccar/traccar-web/assets/31902485/ff4c7ab7-a4ab-4373-ba4b-d2274c0535c0)
