### PR TITLE
PWA fix and improvements

### DIFF
--- a/modern/package-lock.json
+++ b/modern/package-lock.json
@@ -38,7 +38,7 @@
         "recharts": "^2.10.4",
         "redux": "^5.0.1",
         "vite": "^5.0.13",
-        "vite-plugin-pwa": "^0.17.4",
+        "vite-plugin-pwa": "^0.19.7",
         "vite-plugin-svgr": "^4.2.0",
         "wellknown": "^0.5.0"
       },
@@ -11185,9 +11185,9 @@
       }
     },
     "node_modules/vite-plugin-pwa": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-0.17.4.tgz",
-      "integrity": "sha512-j9iiyinFOYyof4Zk3Q+DtmYyDVBDAi6PuMGNGq6uGI0pw7E+LNm9e+nQ2ep9obMP/kjdWwzilqUrlfVRj9OobA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-0.19.7.tgz",
+      "integrity": "sha512-18TECxoGPQE7tVZzKxbf5Icrl5688n1JGMPSgGotTsh89vLDxevY7ICfD3CFVfonZXh8ckuyJXg0NXE5+FAl2A==",
       "dependencies": {
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
@@ -11202,9 +11202,15 @@
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
+        "@vite-pwa/assets-generator": "^0.2.4",
         "vite": "^3.1.0 || ^4.0.0 || ^5.0.0",
         "workbox-build": "^7.0.0",
         "workbox-window": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vite-pwa/assets-generator": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite-plugin-svgr": {

--- a/modern/package.json
+++ b/modern/package.json
@@ -34,7 +34,7 @@
     "recharts": "^2.10.4",
     "redux": "^5.0.1",
     "vite": "^5.0.13",
-    "vite-plugin-pwa": "^0.17.4",
+    "vite-plugin-pwa": "^0.19.7",
     "vite-plugin-svgr": "^4.2.0",
     "wellknown": "^0.5.0"
   },

--- a/modern/vite.config.js
+++ b/modern/vite.config.js
@@ -19,8 +19,11 @@ export default defineConfig(() => ({
     svgr(),
     react(),
     VitePWA({
+      includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png'],
       workbox: {
         navigateFallbackDenylist: [/^\/api/],
+        maximumFileSizeToCacheInBytes: 4000000,
+        globPatterns: ['**/*.{js,css,html,woff,woff2,mp3}'],
       },
       manifest: {
         short_name: '${title}',


### PR DESCRIPTION
After finally finding some time to debug why the PWA is not handling errors (like no internet connection) good - only white blank page was displayed I finally figured out what's happening. 

Because the index.js size grew beyond 2MB, it did not get pre-cached in the Service Worker of the PWA. This warning was nicely displayed in every build, but I just missed it before:
```
warnings
  assets/index-T6yVBWG0.js is 3.82 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.
``` 
This then meant that the html and css was pre-cached in the Service Worker, but the main JS not - which resulted in a blank web page when the main JS was not loadable over HTTP for any reason. 

While working on this, I added all the needed assets to the Service Worker precache (fonts, alarm sound, favicon, apple touch icon) so that the whole PWA is now precached and managed by the Service Worker (like it should from the start). This leads to managed (and displayed) errors and (probably?) improved performance, as everything is precached and managed by the Service Worker (also avoids possibility of mismatched versions of assets).

I also updated the vite-plugin-pwa to the latest version, as there seems to be quite some bugfixing going around there too. This changes were tested on my staging and work great.