### PR TITLE
Return status in handleReboot

### DIFF
--- a/src/settings/PreferencesPage.jsx
+++ b/src/settings/PreferencesPage.jsx
@@ -89,9 +89,7 @@ const PreferencesPage = () => {
 
   const handleReboot = useCatch(async () => {
     const response = await fetch('/api/server/reboot', { method: 'POST' });
-    if (!response.ok) {
-      throw Error(await response.text());
-    }
+    throw Error(response.statusText);
   });
 
   return (


### PR DESCRIPTION
Return response.statusText instead response.text in handleReboot.
Prevents displaying html source of error pages in user feedback

Discussed in [PR #5332](https://github.com/traccar/traccar/pull/5332)