### PR TITLE
draw route with speed based color

### DIFF
--- a/src/common/util/colors.js
+++ b/src/common/util/colors.js
@@ -4,7 +4,7 @@ export const interpolateColor = (color1, color2, factor) => {
   if (factor > 1) factor = 1;
   if (factor < 0) factor = 0;
 
-  const parseRgb = (rgb) => rgb.match(/\d+/g).map(Number);
+  const parseRgb = (rgb) => rgb.split(',').map(Number);
 
   const c1 = parseRgb(hexToRgb(color1));
   const c2 = parseRgb(hexToRgb(color2));

--- a/src/common/util/colors.js
+++ b/src/common/util/colors.js
@@ -1,17 +1,17 @@
-import { hexToRgb, rgbToHex, decomposeColor } from '@mui/material';
+import { decomposeColor } from '@mui/material';
 
 export const interpolateColor = (color1, color2, factor) => {
   if (factor > 1) factor = 1;
   if (factor < 0) factor = 0;
 
-  const c1 = decomposeColor(hexToRgb(color1)).values;
-  const c2 = decomposeColor(hexToRgb(color2)).values;
+  const c1 = decomposeColor(color1).values;
+  const c2 = decomposeColor(color2).values;
 
   const r = Math.round(c1[0] + factor * (c2[0] - c1[0]));
   const g = Math.round(c1[1] + factor * (c2[1] - c1[1]));
   const b = Math.round(c1[2] + factor * (c2[2] - c1[2]));
 
-  return rgbToHex(`rgb(${r}, ${g}, ${b})`);
+  return `rgb(${r}, ${g}, ${b})`;
 };
 
 export const getSpeedColor = (speed, max) => interpolateColor('#FFFF00', '#FF0000', speed / max);

--- a/src/common/util/colors.js
+++ b/src/common/util/colors.js
@@ -14,4 +14,4 @@ export const interpolateColor = (color1, color2, factor) => {
   return `rgb(${r}, ${g}, ${b})`;
 };
 
-export const getSpeedColor = (speed, max) => interpolateColor('#FFFF00', '#FF0000', speed / max);
+export const getSpeedColor = (color1, color2, speed, max) => interpolateColor(color1, color2, speed / max);

--- a/src/common/util/colors.js
+++ b/src/common/util/colors.js
@@ -4,10 +4,8 @@ export const interpolateColor = (color1, color2, factor) => {
   if (factor > 1) factor = 1;
   if (factor < 0) factor = 0;
 
-  const parseRgb = (rgb) => rgb.split(',').map(Number);
-
-  const c1 = parseRgb(hexToRgb(color1));
-  const c2 = parseRgb(hexToRgb(color2));
+  const c1 = hexToRgb(color1).split(',').map(Number);
+  const c2 = hexToRgb(color2).split(',').map(Number);
 
   const r = Math.round(c1[0] + factor * (c2[0] - c1[0]));
   const g = Math.round(c1[1] + factor * (c2[1] - c1[1]));

--- a/src/common/util/colors.js
+++ b/src/common/util/colors.js
@@ -1,11 +1,11 @@
-import { hexToRgb, rgbToHex } from '@mui/material';
+import { hexToRgb, rgbToHex, decomposeColor } from '@mui/material';
 
 export const interpolateColor = (color1, color2, factor) => {
   if (factor > 1) factor = 1;
   if (factor < 0) factor = 0;
 
-  const c1 = hexToRgb(color1).split(',').map(Number);
-  const c2 = hexToRgb(color2).split(',').map(Number);
+  const c1 = decomposeColor(hexToRgb(color1)).values;
+  const c2 = decomposeColor(hexToRgb(color2)).values;
 
   const r = Math.round(c1[0] + factor * (c2[0] - c1[0]));
   const g = Math.round(c1[1] + factor * (c2[1] - c1[1]));

--- a/src/common/util/colors.js
+++ b/src/common/util/colors.js
@@ -14,4 +14,10 @@ export const interpolateColor = (color1, color2, factor) => {
   return `rgb(${r}, ${g}, ${b})`;
 };
 
-export const getSpeedColor = (color1, color2, speed, max) => interpolateColor(color1, color2, speed / max);
+export const getSpeedColor = (color1, color2, color3, speed, max) => {
+  const factor = speed / max;
+  if (factor <= 0.5) {
+    return interpolateColor(color1, color2, factor * 2);
+  }
+  return interpolateColor(color2, color3, (factor - 0.5) * 2);
+};

--- a/src/common/util/colors.js
+++ b/src/common/util/colors.js
@@ -1,0 +1,19 @@
+import { hexToRgb, rgbToHex } from '@mui/material';
+
+export const interpolateColor = (color1, color2, factor) => {
+  if (factor > 1) factor = 1;
+  if (factor < 0) factor = 0;
+
+  const parseRgb = (rgb) => rgb.match(/\d+/g).map(Number);
+
+  const c1 = parseRgb(hexToRgb(color1));
+  const c2 = parseRgb(hexToRgb(color2));
+
+  const r = Math.round(c1[0] + factor * (c2[0] - c1[0]));
+  const g = Math.round(c1[1] + factor * (c2[1] - c1[1]));
+  const b = Math.round(c1[2] + factor * (c2[2] - c1[2]));
+
+  return rgbToHex(`rgb(${r}, ${g}, ${b})`);
+};
+
+export const getSpeedColor = (speed, max) => interpolateColor('#FFFF00', '#FF0000', speed / max);

--- a/src/map/MapRoutePath.js
+++ b/src/map/MapRoutePath.js
@@ -92,7 +92,7 @@ const MapRoutePath = ({ name, positions, coordinates }) => {
           coordinates: [[p1.longitude, p1.latitude], [p2.longitude, p2.latitude]],
         },
         properties: {
-          color: getSpeedColor(theme.palette.error.main, theme.palette.warning.main, theme.palette.success.main, p1.speed, maxSpeed),
+          color: getSpeedColor(theme.palette.success.main, theme.palette.warning.main, theme.palette.error.main, p1.speed, maxSpeed),
         },
       });
     }

--- a/src/map/MapRoutePath.js
+++ b/src/map/MapRoutePath.js
@@ -93,7 +93,7 @@ const MapRoutePath = ({ name, positions, coordinates }) => {
           coordinates: [[p1.longitude, p1.latitude], [p2.longitude, p2.latitude]],
         },
         properties: {
-          color: getSpeedColor(p1.speed, maxSpeed),
+          color: getSpeedColor(theme.palette.warning.main, theme.palette.error.main, p1.speed, maxSpeed),
         },
       });
     }

--- a/src/map/MapRoutePath.js
+++ b/src/map/MapRoutePath.js
@@ -93,7 +93,7 @@ const MapRoutePath = ({ name, positions, coordinates }) => {
           coordinates: [[p1.longitude, p1.latitude], [p2.longitude, p2.latitude]],
         },
         properties: {
-          color: getSpeedColor(theme.palette.warning.main, theme.palette.error.main, p1.speed, maxSpeed),
+          color: getSpeedColor(theme.palette.error.main, theme.palette.warning.main, theme.palette.success.main, p1.speed, maxSpeed),
         },
       });
     }

--- a/src/map/MapRoutePath.js
+++ b/src/map/MapRoutePath.js
@@ -1,7 +1,6 @@
 import { useTheme } from '@mui/styles';
 import { useId, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { featureCollection } from '@turf/turf';
 import { map } from './core/MapView';
 import { getSpeedColor } from '../common/util/colors';
 
@@ -98,7 +97,10 @@ const MapRoutePath = ({ name, positions, coordinates }) => {
       });
     }
 
-    map.getSource(id)?.setData(featureCollection(features));
+    map.getSource(id)?.setData({
+      type: 'FeatureCollection',
+      features,
+    });
   }, [theme, positions, coordinates, reportColor]);
 
   return null;

--- a/src/map/MapRoutePath.js
+++ b/src/map/MapRoutePath.js
@@ -1,7 +1,7 @@
 import { useTheme } from '@mui/styles';
 import { useId, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { featureCollection, lineString } from '@turf/turf';
+import { featureCollection } from '@turf/turf';
 import { map } from './core/MapView';
 import { getSpeedColor } from '../common/util/colors';
 
@@ -86,10 +86,16 @@ const MapRoutePath = ({ name, positions, coordinates }) => {
     for (let i = 0; i < positions.length - 1; i += 1) {
       const p1 = positions[i];
       const p2 = positions[i + 1];
-      features.push(lineString(
-        [[p1.longitude, p1.latitude], [p2.longitude, p2.latitude]],
-        { color: getSpeedColor(p1.speed, maxSpeed) },
-      ));
+      features.push({
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: [[p1.longitude, p1.latitude], [p2.longitude, p2.latitude]],
+        },
+        properties: {
+          color: getSpeedColor(p1.speed, maxSpeed),
+        },
+      });
     }
 
     map.getSource(id)?.setData(featureCollection(features));

--- a/src/map/MapRoutePoints.js
+++ b/src/map/MapRoutePoints.js
@@ -72,7 +72,7 @@ const MapRoutePoints = ({ positions, onClick }) => {
           index,
           id: position.id,
           rotation: position.course,
-          color: getSpeedColor(theme.palette.error.main, theme.palette.warning.main, theme.palette.success.main, position.speed, maxSpeed),
+          color: getSpeedColor(theme.palette.success.main, theme.palette.warning.main, theme.palette.error.main, position.speed, maxSpeed),
         },
       })),
     });

--- a/src/map/MapRoutePoints.js
+++ b/src/map/MapRoutePoints.js
@@ -1,5 +1,6 @@
 import { useId, useCallback, useEffect } from 'react';
 import { map } from './core/MapView';
+import { getSpeedColor } from '../common/util/colors';
 
 const MapRoutePoints = ({ positions, onClick }) => {
   const id = useId();
@@ -27,11 +28,13 @@ const MapRoutePoints = ({ positions, onClick }) => {
       id,
       type: 'symbol',
       source: id,
+      paint: {
+        'text-color': ['get', 'color'],
+      },
       layout: {
-        'icon-image': 'arrow',
-        'icon-allow-overlap': true,
-        'icon-rotate': ['get', 'rotation'],
-        'icon-rotation-alignment': 'map',
+        'text-field': '▲',
+        'text-allow-overlap': true,
+        'text-rotate': ['get', 'rotation'],
       },
     });
 
@@ -54,6 +57,7 @@ const MapRoutePoints = ({ positions, onClick }) => {
   }, [onMarkerClick]);
 
   useEffect(() => {
+    const maxSpeed = positions.map((p) => p.speed).reduce((a, b) => Math.max(a, b), -Infinity);
     map.getSource(id)?.setData({
       type: 'FeatureCollection',
       features: positions.map((position, index) => ({
@@ -66,6 +70,7 @@ const MapRoutePoints = ({ positions, onClick }) => {
           index,
           id: position.id,
           rotation: position.course,
+          color: getSpeedColor(position.speed, maxSpeed),
         },
       })),
     });

--- a/src/map/MapRoutePoints.js
+++ b/src/map/MapRoutePoints.js
@@ -1,9 +1,11 @@
 import { useId, useCallback, useEffect } from 'react';
+import { useTheme } from '@mui/styles';
 import { map } from './core/MapView';
 import { getSpeedColor } from '../common/util/colors';
 
 const MapRoutePoints = ({ positions, onClick }) => {
   const id = useId();
+  const theme = useTheme();
 
   const onMouseEnter = () => map.getCanvas().style.cursor = 'pointer';
   const onMouseLeave = () => map.getCanvas().style.cursor = '';
@@ -70,7 +72,7 @@ const MapRoutePoints = ({ positions, onClick }) => {
           index,
           id: position.id,
           rotation: position.course,
-          color: getSpeedColor(position.speed, maxSpeed),
+          color: getSpeedColor(theme.palette.warning.main, theme.palette.error.main, position.speed, maxSpeed),
         },
       })),
     });

--- a/src/map/MapRoutePoints.js
+++ b/src/map/MapRoutePoints.js
@@ -72,7 +72,7 @@ const MapRoutePoints = ({ positions, onClick }) => {
           index,
           id: position.id,
           rotation: position.course,
-          color: getSpeedColor(theme.palette.warning.main, theme.palette.error.main, position.speed, maxSpeed),
+          color: getSpeedColor(theme.palette.error.main, theme.palette.warning.main, theme.palette.success.main, position.speed, maxSpeed),
         },
       })),
     });

--- a/src/map/core/preloadImages.js
+++ b/src/map/core/preloadImages.js
@@ -2,7 +2,6 @@ import { grey } from '@mui/material/colors';
 import createPalette from '@mui/material/styles/createPalette';
 import { loadImage, prepareIcon } from './mapUtil';
 
-import arrowSvg from '../../resources/images/arrow.svg';
 import directionSvg from '../../resources/images/direction.svg';
 import backgroundSvg from '../../resources/images/background.svg';
 import animalSvg from '../../resources/images/icon/animal.svg';
@@ -65,7 +64,6 @@ export default async () => {
   const background = await loadImage(backgroundSvg);
   mapImages.background = await prepareIcon(background);
   mapImages.direction = await prepareIcon(await loadImage(directionSvg));
-  mapImages.arrow = await prepareIcon(await loadImage(arrowSvg));
   await Promise.all(Object.keys(mapIcons).map(async (category) => {
     const results = [];
     ['info', 'success', 'error', 'neutral'].forEach((color) => {

--- a/src/resources/images/arrow.svg
+++ b/src/resources/images/arrow.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="20px" fill="#000000" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
- <path d="m12 2-7.5 18.29 0.71 0.71 6.79-3 6.79 3 0.71-0.71z" fill="#3bb2d0"/>
-</svg>


### PR DESCRIPTION
Draw the route with intepolated color.
Changed MapRoutePoints arrow to text instead of icon so that we can change the color.
I tried to use the palette instead of the hard coded yellow and red colors, but it didn't look good.

<img width="504" alt="Captura de ecrã 2024-06-16, às 20 00 39" src="https://github.com/traccar/traccar-web/assets/31902485/8bbf787c-43f5-4f3d-a1bb-f62bd5e7f473">
