### PR TITLE
Chart Report - Allow multiple X Axis for different time indexes

### DIFF
--- a/src/reports/ChartReportPage.jsx
+++ b/src/reports/ChartReportPage.jsx
@@ -142,7 +142,6 @@ const ChartReportPage = () => {
             >
               <XAxis
                 dataKey={timeType}
-                interval="preserveStartEnd"
                 type="number"
                 tickFormatter={(value) => formatTime(value, 'time')}
                 domain={['dataMin', 'dataMax']}

--- a/src/reports/ChartReportPage.jsx
+++ b/src/reports/ChartReportPage.jsx
@@ -33,6 +33,7 @@ const ChartReportPage = () => {
   const [items, setItems] = useState([]);
   const [types, setTypes] = useState(['speed']);
   const [type, setType] = useState('speed');
+  const [timeIndex, setTimeIndex] = useState('fixTime');
 
   const values = items.map((it) => it[type]);
   const minValue = Math.min(...values);
@@ -52,6 +53,8 @@ const ChartReportPage = () => {
         const data = { ...position, ...position.attributes };
         const formatted = {};
         formatted.fixTime = dayjs(position.fixTime).valueOf();
+        formatted.deviceTime = dayjs(position.deviceTime).valueOf();
+        formatted.serverTime = dayjs(position.serverTime).valueOf();
         Object.keys(data).filter((key) => !['id', 'deviceId'].includes(key)).forEach((key) => {
           const value = data[key];
           if (typeof value === 'number') {
@@ -112,6 +115,21 @@ const ChartReportPage = () => {
             </Select>
           </FormControl>
         </div>
+        <div className={classes.filterItem}>
+          <FormControl fullWidth>
+            <InputLabel>{t('commandIndex')}</InputLabel>
+            <Select
+              label={t('commandIndex')}
+              value={timeIndex}
+              onChange={(e) => setTimeIndex(e.target.value)}
+              disabled={!items.length}
+            >
+              <MenuItem value="fixTime">{t('positionFixTime')}</MenuItem>
+              <MenuItem value="deviceTime">{t('positionDeviceTime')}</MenuItem>
+              <MenuItem value="serverTime">{t('positionServerTime')}</MenuItem>
+            </Select>
+          </FormControl>
+        </div>
       </ReportFilter>
       {items.length > 0 && (
         <div className={classes.chart}>
@@ -123,7 +141,8 @@ const ChartReportPage = () => {
               }}
             >
               <XAxis
-                dataKey="fixTime"
+                dataKey={timeIndex}
+                interval="preserveStartEnd"
                 type="number"
                 tickFormatter={(value) => formatTime(value, 'time')}
                 domain={['dataMin', 'dataMax']}

--- a/src/reports/ChartReportPage.jsx
+++ b/src/reports/ChartReportPage.jsx
@@ -117,9 +117,9 @@ const ChartReportPage = () => {
         </div>
         <div className={classes.filterItem}>
           <FormControl fullWidth>
-            <InputLabel>{t('commandIndex')}</InputLabel>
+            <InputLabel>{t('reportTimeType')}</InputLabel>
             <Select
-              label={t('commandIndex')}
+              label={t('reportTimeType')}
               value={timeType}
               onChange={(e) => setTimeType(e.target.value)}
               disabled={!items.length}

--- a/src/reports/ChartReportPage.jsx
+++ b/src/reports/ChartReportPage.jsx
@@ -33,7 +33,7 @@ const ChartReportPage = () => {
   const [items, setItems] = useState([]);
   const [types, setTypes] = useState(['speed']);
   const [type, setType] = useState('speed');
-  const [timeIndex, setTimeIndex] = useState('fixTime');
+  const [timeType, setTimeType] = useState('fixTime');
 
   const values = items.map((it) => it[type]);
   const minValue = Math.min(...values);
@@ -120,8 +120,8 @@ const ChartReportPage = () => {
             <InputLabel>{t('commandIndex')}</InputLabel>
             <Select
               label={t('commandIndex')}
-              value={timeIndex}
-              onChange={(e) => setTimeIndex(e.target.value)}
+              value={timeType}
+              onChange={(e) => setTimeType(e.target.value)}
               disabled={!items.length}
             >
               <MenuItem value="fixTime">{t('positionFixTime')}</MenuItem>
@@ -141,7 +141,7 @@ const ChartReportPage = () => {
               }}
             >
               <XAxis
-                dataKey={timeIndex}
+                dataKey={timeType}
                 interval="preserveStartEnd"
                 type="number"
                 tickFormatter={(value) => formatTime(value, 'time')}

--- a/src/resources/l10n/en.json
+++ b/src/resources/l10n/en.json
@@ -575,6 +575,7 @@
     "reportSpentFuel": "Spent Fuel",
     "reportStartOdometer": "Odometer Start",
     "reportEndOdometer": "Odometer End",
+    "reportTimeType": "Time",
     "statisticsTitle": "Statistics",
     "statisticsCaptureTime": "Capture Time",
     "statisticsActiveUsers": "Active Users",


### PR DESCRIPTION
I noticed an issue displaying some data in Chart Reports.
For devices that periodically disable GPS, 'fixTime' can be the same across multiple updates, while other data changes.

So displaying 'Battery Level' over time for example, results in stacked ticks, because 'fixTime' is used for the X axis:
![image](https://github.com/traccar/traccar-web/assets/14150258/4d70a2a1-a850-4c87-ac6e-fded2f00300e)

This is probably ideal behavior for some data, but not for others. Proposed solution is allowing user to choose which time to use by adding an extra select filter on chart reports:
![image](https://github.com/traccar/traccar-web/assets/14150258/4c410756-7f30-4d32-8779-ce1c79f9b0be)

I'm not convinced its the best approach, but its the simplest I could think of.

Criticism is welcome 😄 