### PR TITLE
Update the itemsCoordinates state every time the length of itemsRoute…

### DIFF
--- a/src/reports/CombinedReportPage.jsx
+++ b/src/reports/CombinedReportPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   Table, TableBody, TableCell, TableHead, TableRow,
@@ -26,6 +26,13 @@ const CombinedReportPage = () => {
 
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [itemsCoordinates, setItemsCoordinates] = useState([]);
+
+  const itemsRoutes = items.flatMap((item) => item.route);
+
+  useEffect(() => {
+    setItemsCoordinates(itemsRoutes);
+  }, [itemsRoutes.length]);
 
   const createMarkers = () => items.flatMap((item) => item.events
     .map((event) => item.positions.find((p) => event.positionId === p.id))
@@ -68,7 +75,7 @@ const CombinedReportPage = () => {
               ))}
               <MapMarkers markers={createMarkers()} />
             </MapView>
-            <MapCamera coordinates={items.flatMap((item) => item.route)} />
+            <MapCamera coordinates={itemsCoordinates} />
           </div>
         )}
         <div className={classes.containerMain}>

--- a/src/reports/CombinedReportPage.jsx
+++ b/src/reports/CombinedReportPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   Table, TableBody, TableCell, TableHead, TableRow,
@@ -26,13 +26,8 @@ const CombinedReportPage = () => {
 
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [itemsCoordinates, setItemsCoordinates] = useState([]);
 
-  const itemsRoutes = items.flatMap((item) => item.route);
-
-  useEffect(() => {
-    setItemsCoordinates(itemsRoutes);
-  }, [itemsRoutes.length]);
+  const itemsCoordinates = useMemo(() => items.flatMap((item) => item.route), [items]);
 
   const createMarkers = () => items.flatMap((item) => item.events
     .map((event) => item.positions.find((p) => event.positionId === p.id))


### PR DESCRIPTION
Hello, I hope this PR is helpful to you.

##
Update the itemsCoordinates state every time the length of itemsRoutes changes.

## Before -> the map was returning to its initial state when the state was updated with the socket
https://github.com/traccar/traccar-web/assets/92123185/2c3e0279-eb36-471f-8787-ea079ccfbde7



## After 
https://github.com/traccar/traccar-web/assets/92123185/9bc325df-fc87-4fee-8170-9286ccaf5102

