### PR TITLE
fix: useMemo in menus

### DIFF
--- a/src/common/components/PageLayout.jsx
+++ b/src/common/components/PageLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   AppBar,
   Breadcrumbs,
@@ -74,6 +74,8 @@ const PageLayout = ({ menu, breadcrumbs, children }) => {
 
   const [openDrawer, setOpenDrawer] = useState(false);
 
+  const menuMemo = useMemo(() => menu, []);
+
   return desktop ? (
     <div className={classes.desktopRoot}>
       <Drawer
@@ -88,7 +90,7 @@ const PageLayout = ({ menu, breadcrumbs, children }) => {
           <PageTitle breadcrumbs={breadcrumbs} />
         </Toolbar>
         <Divider />
-        {menu}
+        {menuMemo}
       </Drawer>
       <div className={classes.content}>{children}</div>
     </div>

--- a/src/common/components/PageLayout.jsx
+++ b/src/common/components/PageLayout.jsx
@@ -102,7 +102,7 @@ const PageLayout = ({ menu, breadcrumbs, children }) => {
         onClose={() => setOpenDrawer(false)}
         classes={{ paper: classes.mobileDrawer }}
       >
-        {menu}
+        {menuMemo}
       </Drawer>
       <AppBar className={classes.mobileToolbar} position="static" color="inherit">
         <Toolbar>

--- a/src/settings/components/EditItemView.jsx
+++ b/src/settings/components/EditItemView.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   Container, Button, Accordion, AccordionDetails, AccordionSummary, Skeleton, Typography, TextField,
@@ -54,8 +54,10 @@ const EditItemView = ({
     }
   });
 
+  const menuMemo = useMemo(() => menu, []);
+
   return (
-    <PageLayout menu={menu} breadcrumbs={breadcrumbs}>
+    <PageLayout menu={menuMemo} breadcrumbs={breadcrumbs}>
       <Container maxWidth="xs" className={classes.container}>
         {item ? children : (
           <Accordion defaultExpanded>


### PR DESCRIPTION
Prevent re-rendering of report and settings menus. 
This solution would maintain the structure of your project and would not be as complex as @ #1252 