### PR TITLE
maximumFileSizeToCacheInBytes to 5Mb

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig(() => ({
       includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png'],
       workbox: {
         navigateFallbackDenylist: [/^\/api/],
-        maximumFileSizeToCacheInBytes: 5000000,
+        maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
         globPatterns: ['**/*.{js,css,html,woff,woff2,mp3}'],
       },
       manifest: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig(() => ({
       includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png'],
       workbox: {
         navigateFallbackDenylist: [/^\/api/],
-        maximumFileSizeToCacheInBytes: 4000000,
+        maximumFileSizeToCacheInBytes: 5000000,
         globPatterns: ['**/*.{js,css,html,woff,woff2,mp3}'],
       },
       manifest: {


### PR DESCRIPTION
The main javascript file is not being cached by the service worker be cause it passes the 4Mb limit.

The problem here is the server updates. If you update the server with a new build, the page won't open because the service worker will try to fetch and old javascript file which doesn't exist anymore. 

It can be stuck forever. For it to update you have to shutdown the browser (not just refresh the page or close the tab/window) so that all clients release the active service worker. 

If we cache the main javascript we won't have this problem, the page will open and the popup for the update will appear. 

<img width="1440" alt="Captura de ecrã 2024-08-23, às 23 33 18" src="https://github.com/user-attachments/assets/f000e375-f676-49ef-ad38-96781fe96871">
