### PR TITLE
Allow managers to see device's users

### DIFF
--- a/src/settings/DevicesPage.jsx
+++ b/src/settings/DevicesPage.jsx
@@ -14,7 +14,7 @@ import CollectionActions from './components/CollectionActions';
 import TableShimmer from '../common/components/TableShimmer';
 import SearchHeader, { filterByKeyword } from './components/SearchHeader';
 import { formatTime } from '../common/util/formatter';
-import { useAdministrator, useDeviceReadonly } from '../common/util/permissions';
+import { useDeviceReadonly, useManager } from '../common/util/permissions';
 import useSettingsStyles from './common/useSettingsStyles';
 import DeviceUsersValue from './components/DeviceUsersValue';
 
@@ -25,7 +25,7 @@ const DevicesPage = () => {
 
   const groups = useSelector((state) => state.groups.items);
 
-  const admin = useAdministrator();
+  const manager = useManager();
   const deviceReadonly = useDeviceReadonly();
 
   const [timestamp, setTimestamp] = useState(Date.now());
@@ -73,7 +73,7 @@ const DevicesPage = () => {
             <TableCell>{t('deviceModel')}</TableCell>
             <TableCell>{t('deviceContact')}</TableCell>
             <TableCell>{t('userExpirationTime')}</TableCell>
-            {admin && <TableCell>{t('settingsUsers')}</TableCell>}
+            {manager && <TableCell>{t('settingsUsers')}</TableCell>}
             <TableCell className={classes.columnAction} />
           </TableRow>
         </TableHead>
@@ -87,7 +87,7 @@ const DevicesPage = () => {
               <TableCell>{item.model}</TableCell>
               <TableCell>{item.contact}</TableCell>
               <TableCell>{formatTime(item.expirationTime, 'date')}</TableCell>
-              {admin && <TableCell><DeviceUsersValue deviceId={item.id} /></TableCell>}
+              {manager && <TableCell><DeviceUsersValue deviceId={item.id} /></TableCell>}
               <TableCell className={classes.columnAction} padding="none">
                 <CollectionActions
                   itemId={item.id}
@@ -99,14 +99,14 @@ const DevicesPage = () => {
                 />
               </TableCell>
             </TableRow>
-          )) : (<TableShimmer columns={admin ? 8 : 7} endAction />)}
+          )) : (<TableShimmer columns={manager ? 8 : 7} endAction />)}
         </TableBody>
         <TableFooter>
           <TableRow>
             <TableCell>
               <Button onClick={handleExport} variant="text">{t('reportExport')}</Button>
             </TableCell>
-            <TableCell colSpan={admin ? 8 : 7} align="right">
+            <TableCell colSpan={manager ? 8 : 7} align="right">
               <FormControlLabel
                 control={(
                   <Switch
@@ -117,7 +117,7 @@ const DevicesPage = () => {
                 )}
                 label={t('notificationAlways')}
                 labelPlacement="start"
-                disabled={!admin}
+                disabled={!manager}
               />
             </TableCell>
           </TableRow>


### PR DESCRIPTION
Managers should also be allowed to see wich of their users are linked to devices, since they can have many users bellow them to manage.