### PR TITLE
Add navigation app link in status card

### DIFF
--- a/src/common/attributes/useCommonUserAttributes.js
+++ b/src/common/attributes/useCommonUserAttributes.js
@@ -137,4 +137,12 @@ export default (t) => useMemo(() => ({
     name: t('sharedIconScale'),
     type: 'number',
   },
+  navigationAppLink: {
+    name: t('navigationAppLink'),
+    type: 'string',
+  },
+  navigationAppTitle: {
+    name: t('navigationAppTitle'),
+    type: 'string',
+  },
 }), [t]);

--- a/src/common/attributes/useCommonUserAttributes.js
+++ b/src/common/attributes/useCommonUserAttributes.js
@@ -138,11 +138,11 @@ export default (t) => useMemo(() => ({
     type: 'number',
   },
   navigationAppLink: {
-    name: t('navigationAppLink'),
+    name: t('attributeNavigationAppLink'),
     type: 'string',
   },
   navigationAppTitle: {
-    name: t('navigationAppTitle'),
+    name: t('attributeNavigationAppTitle'),
     type: 'string',
   },
 }), [t]);

--- a/src/common/components/StatusCard.jsx
+++ b/src/common/components/StatusCard.jsx
@@ -126,6 +126,11 @@ const StatusCard = ({ deviceId, position, onClose, disableActions, desktopPaddin
   const positionAttributes = usePositionAttributes(t);
   const positionItems = useAttributePreference('positionItems', 'fixTime,address,speed,totalDistance');
 
+  const serverNavigationAppLink = useSelector((state) => state.session.server.attributes.navigationAppLink);
+  const serverNavigationAppTitle = useSelector((state) => state.session.server.attributes.navigationAppTitle);
+  const userNavigationAppLink = user.attributes.navigationAppLink;
+  const userNavigationAppTitle = user.attributes.navigationAppTitle;
+
   const [anchorEl, setAnchorEl] = useState(null);
 
   const [removing, setRemoving] = useState(false);
@@ -269,6 +274,8 @@ const StatusCard = ({ deviceId, position, onClose, disableActions, desktopPaddin
           <MenuItem component="a" target="_blank" href={`https://www.google.com/maps/search/?api=1&query=${position.latitude}%2C${position.longitude}`}>{t('linkGoogleMaps')}</MenuItem>
           <MenuItem component="a" target="_blank" href={`http://maps.apple.com/?ll=${position.latitude},${position.longitude}`}>{t('linkAppleMaps')}</MenuItem>
           <MenuItem component="a" target="_blank" href={`https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${position.latitude}%2C${position.longitude}&heading=${position.course}`}>{t('linkStreetView')}</MenuItem>
+          {serverNavigationAppLink && serverNavigationAppTitle && <MenuItem component="a" target="_blank" href={serverNavigationAppLink.replace('{latitude}', position.latitude).replace('{longitude}', position.longitude)}>{serverNavigationAppTitle}</MenuItem>}
+          {userNavigationAppLink && userNavigationAppTitle && <MenuItem component="a" target="_blank" href={userNavigationAppLink.replace('{latitude}', position.latitude).replace('{longitude}', position.longitude)}>{userNavigationAppTitle}</MenuItem>}
           {!shareDisabled && !user.temporary && <MenuItem onClick={() => navigate(`/settings/device/${deviceId}/share`)}>{t('deviceShare')}</MenuItem>}
         </Menu>
       )}

--- a/src/common/components/StatusCard.jsx
+++ b/src/common/components/StatusCard.jsx
@@ -126,10 +126,8 @@ const StatusCard = ({ deviceId, position, onClose, disableActions, desktopPaddin
   const positionAttributes = usePositionAttributes(t);
   const positionItems = useAttributePreference('positionItems', 'fixTime,address,speed,totalDistance');
 
-  const serverNavigationAppLink = useSelector((state) => state.session.server.attributes.navigationAppLink);
-  const serverNavigationAppTitle = useSelector((state) => state.session.server.attributes.navigationAppTitle);
-  const userNavigationAppLink = user.attributes.navigationAppLink;
-  const userNavigationAppTitle = user.attributes.navigationAppTitle;
+  const navigationAppLink = useAttributePreference('navigationAppLink');
+  const navigationAppTitle = useAttributePreference('navigationAppTitle');
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -274,8 +272,7 @@ const StatusCard = ({ deviceId, position, onClose, disableActions, desktopPaddin
           <MenuItem component="a" target="_blank" href={`https://www.google.com/maps/search/?api=1&query=${position.latitude}%2C${position.longitude}`}>{t('linkGoogleMaps')}</MenuItem>
           <MenuItem component="a" target="_blank" href={`http://maps.apple.com/?ll=${position.latitude},${position.longitude}`}>{t('linkAppleMaps')}</MenuItem>
           <MenuItem component="a" target="_blank" href={`https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${position.latitude}%2C${position.longitude}&heading=${position.course}`}>{t('linkStreetView')}</MenuItem>
-          {serverNavigationAppLink && serverNavigationAppTitle && <MenuItem component="a" target="_blank" href={serverNavigationAppLink.replace('{latitude}', position.latitude).replace('{longitude}', position.longitude)}>{serverNavigationAppTitle}</MenuItem>}
-          {userNavigationAppLink && userNavigationAppTitle && <MenuItem component="a" target="_blank" href={userNavigationAppLink.replace('{latitude}', position.latitude).replace('{longitude}', position.longitude)}>{userNavigationAppTitle}</MenuItem>}
+          {navigationAppTitle && <MenuItem component="a" target="_blank" href={navigationAppLink.replace('{latitude}', position.latitude).replace('{longitude}', position.longitude)}>{navigationAppTitle}</MenuItem>}
           {!shareDisabled && !user.temporary && <MenuItem onClick={() => navigate(`/settings/device/${deviceId}/share`)}>{t('deviceShare')}</MenuItem>}
         </Menu>
       )}

--- a/src/resources/l10n/en.json
+++ b/src/resources/l10n/en.json
@@ -150,6 +150,8 @@
     "attributeMailSmtpAuth": "Mail: SMTP Auth Enable",
     "attributeMailSmtpUsername": "Mail: SMTP Username",
     "attributeMailSmtpPassword": "Mail: SMTP Password",
+    "attributeNavigationAppLink": "Navigation app link",
+    "attributeNavigationAppTitle": "Navigation app title",
     "attributeUiDisableSavedCommands": "UI: Disable Saved Commands",
     "attributeUiDisableAttributes": "UI: Disable Attributes",
     "attributeUiDisableGroups": "UI: Disable Groups",
@@ -609,7 +611,5 @@
     "categoryVan": "Van",
     "categoryScooter": "Scooter",
     "maintenanceStart": "Start",
-    "maintenancePeriod": "Period",
-    "navigationAppLink": "Navigation app link",
-    "navigationAppTitle": "Navigation app title"
+    "maintenancePeriod": "Period"
 }

--- a/src/resources/l10n/en.json
+++ b/src/resources/l10n/en.json
@@ -609,5 +609,7 @@
     "categoryVan": "Van",
     "categoryScooter": "Scooter",
     "maintenanceStart": "Start",
-    "maintenancePeriod": "Period"
+    "maintenancePeriod": "Period",
+    "navigationAppLink": "Navigation app link",
+    "navigationAppTitle": "Navigation app title"
 }


### PR DESCRIPTION
Hello,

I often need to reach the position of my trackers but I prefer to use Waze.

Before, I had to open the link for Google Maps, copy latlon coordinates, open Waze manually and paste the coordinates.

With this query we add a "Waze" entry to the status card menu:

![image](https://github.com/user-attachments/assets/8e26c87c-d05d-468a-82df-e17afe08b6e2)

This will trigger the Waze app to open on the smartphone.

I have successfully tested this locally with an Android phone.