### PR TITLE
Changed function call after color normalization fix, and unified var …

### DIFF
--- a/src/map/MapRoutePath.js
+++ b/src/map/MapRoutePath.js
@@ -62,7 +62,8 @@ const MapRoutePath = ({ positions }) => {
   }, []);
 
   useEffect(() => {
-    const maxSpeed = positions.map((item) => item.speed).reduce((a, b) => Math.max(a, b), -Infinity);
+    const minSpeed = positions.map((p) => p.speed).reduce((a, b) => Math.min(a, b), Infinity);
+    const maxSpeed = positions.map((p) => p.speed).reduce((a, b) => Math.max(a, b), -Infinity);
     const features = [];
     for (let i = 0; i < positions.length - 1; i += 1) {
       features.push({
@@ -74,6 +75,7 @@ const MapRoutePath = ({ positions }) => {
         properties: {
           color: reportColor || getSpeedColor(
             positions[i + 1].speed,
+            minSpeed,
             maxSpeed,
           ),
         },


### PR DESCRIPTION
Fixed function call which broke after PR #[1277 ](https://github.com/traccar/traccar-web/pull/1277?notification_referrer_id=NT_kwDOADVDebMxMjc1MDI5NTcwODozNDkwNjgx#issuecomment-2399622555)

**The route lines stayed black, instead of getting colored as expected**
![image](https://github.com/user-attachments/assets/e55c3d10-2686-4a59-ae8d-412973055a35)

After fix:

![image](https://github.com/user-attachments/assets/f8d83ccf-e684-4d95-ba0b-b2d0771526de)