### PR TITLE
Optimize drawer width to reduce wasted space in reports and settings

### DIFF
--- a/src/common/components/MenuItem.jsx
+++ b/src/common/components/MenuItem.jsx
@@ -1,0 +1,22 @@
+import makeStyles from '@mui/styles/makeStyles';
+import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import { Link } from 'react-router-dom';
+import React from 'react';
+
+const MenuItem = ({
+  title, link, icon, selected,
+}) => {
+  const classes = makeStyles({
+    menuItemText: {
+      whiteSpace: 'nowrap',
+    },
+  });
+  return (
+    <ListItemButton key={link} component={Link} to={link} selected={selected}>
+      <ListItemIcon>{icon}</ListItemIcon>
+      <ListItemText primary={title} className={classes.menuItemText} />
+    </ListItemButton>
+  );
+};
+
+export default MenuItem;

--- a/src/common/components/MenuItem.jsx
+++ b/src/common/components/MenuItem.jsx
@@ -3,14 +3,14 @@ import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { Link } from 'react-router-dom';
 import React from 'react';
 
-const MenuItem = ({
-  title, link, icon, selected,
-}) => {
-  const classes = makeStyles({
-    menuItemText: {
-      whiteSpace: 'nowrap',
-    },
-  });
+const useStyles = makeStyles(() => ({
+  menuItemText: {
+    whiteSpace: 'nowrap',
+  },
+}));
+
+const MenuItem = ({ title, link, icon, selected }) => {
+  const classes = useStyles();
   return (
     <ListItemButton key={link} component={Link} to={link} selected={selected}>
       <ListItemIcon>{icon}</ListItemIcon>

--- a/src/common/components/PageLayout.jsx
+++ b/src/common/components/PageLayout.jsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
   },
   desktopDrawer: {
-    width: (props) => (props.miniVariant ? `calc(${theme.spacing(7)} + 1px)` : theme.dimensions.drawerWidthDesktop),
+    width: (props) => (props.miniVariant ? `calc(${theme.spacing(8)} + 1px)` : theme.dimensions.drawerWidthDesktop),
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,

--- a/src/common/components/PageLayout.jsx
+++ b/src/common/components/PageLayout.jsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
   },
   desktopDrawer: {
-    width: (props) => (props.miniVariant ? theme.dimensions.miniDrawerWidthDesktop : theme.dimensions.drawerWidthDesktop),
+    width: (props) => (props.miniVariant ? `calc(${theme.spacing(7)} + 1px)` : theme.dimensions.drawerWidthDesktop),
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,
@@ -81,9 +81,7 @@ const PageLayout = ({ menu, breadcrumbs, children }) => {
 
   const [openDrawer, setOpenDrawer] = useState(false);
 
-  const toggleDrawer = () => {
-    setMiniVariant(!miniVariant);
-  };
+  const toggleDrawer = () => setMiniVariant(!miniVariant);
 
   return desktop ? (
     <div className={classes.desktopRoot}>

--- a/src/common/components/PageLayout.jsx
+++ b/src/common/components/PageLayout.jsx
@@ -12,6 +12,8 @@ import {
 } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import MenuIcon from '@mui/icons-material/Menu';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from './LocalizationProvider';
@@ -27,7 +29,11 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
   },
   desktopDrawer: {
-    width: theme.dimensions.drawerWidthDesktop,
+    width: (props) => (props.miniVariant ? theme.dimensions.miniDrawerWidthDesktop : theme.dimensions.drawerWidthDesktop),
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
   },
   mobileDrawer: {
     width: theme.dimensions.drawerWidthTablet,
@@ -66,13 +72,18 @@ const PageTitle = ({ breadcrumbs }) => {
 };
 
 const PageLayout = ({ menu, breadcrumbs, children }) => {
-  const classes = useStyles();
+  const [miniVariant, setMiniVariant] = useState(false);
+  const classes = useStyles({ miniVariant });
   const theme = useTheme();
   const navigate = useNavigate();
 
   const desktop = useMediaQuery(theme.breakpoints.up('md'));
 
   const [openDrawer, setOpenDrawer] = useState(false);
+
+  const toggleDrawer = () => {
+    setMiniVariant(!miniVariant);
+  };
 
   return desktop ? (
     <div className={classes.desktopRoot}>
@@ -82,10 +93,17 @@ const PageLayout = ({ menu, breadcrumbs, children }) => {
         classes={{ paper: classes.desktopDrawer }}
       >
         <Toolbar>
-          <IconButton color="inherit" edge="start" sx={{ mr: 2 }} onClick={() => navigate('/')}>
-            <ArrowBackIcon />
+          {!miniVariant && (
+          <>
+            <IconButton color="inherit" edge="start" sx={{ mr: 2 }} onClick={() => navigate('/')}>
+              <ArrowBackIcon />
+            </IconButton>
+            <PageTitle breadcrumbs={breadcrumbs} />
+          </>
+          )}
+          <IconButton color="inherit" edge="start" sx={{ ml: miniVariant ? -2 : 'auto' }} onClick={toggleDrawer}>
+            {miniVariant ? <ChevronRightIcon /> : <ChevronLeftIcon />}
           </IconButton>
-          <PageTitle breadcrumbs={breadcrumbs} />
         </Toolbar>
         <Divider />
         {menu}

--- a/src/common/components/PageLayout.jsx
+++ b/src/common/components/PageLayout.jsx
@@ -92,12 +92,12 @@ const PageLayout = ({ menu, breadcrumbs, children }) => {
       >
         <Toolbar>
           {!miniVariant && (
-          <>
-            <IconButton color="inherit" edge="start" sx={{ mr: 2 }} onClick={() => navigate('/')}>
-              <ArrowBackIcon />
-            </IconButton>
-            <PageTitle breadcrumbs={breadcrumbs} />
-          </>
+            <>
+              <IconButton color="inherit" edge="start" sx={{ mr: 2 }} onClick={() => navigate('/')}>
+                <ArrowBackIcon />
+              </IconButton>
+              <PageTitle breadcrumbs={breadcrumbs} />
+            </>
           )}
           <IconButton color="inherit" edge="start" sx={{ ml: miniVariant ? -2 : 'auto' }} onClick={toggleDrawer}>
             {miniVariant ? <ChevronRightIcon /> : <ChevronLeftIcon />}

--- a/src/common/theme/dimensions.js
+++ b/src/common/theme/dimensions.js
@@ -2,7 +2,6 @@ export default {
   sidebarWidth: '28%',
   sidebarWidthTablet: '52px',
   drawerWidthDesktop: '360px',
-  miniDrawerWidthDesktop: '56px',
   drawerWidthTablet: '320px',
   drawerHeightPhone: '250px',
   filterFormWidth: '160px',

--- a/src/common/theme/dimensions.js
+++ b/src/common/theme/dimensions.js
@@ -2,6 +2,7 @@ export default {
   sidebarWidth: '28%',
   sidebarWidthTablet: '52px',
   drawerWidthDesktop: '360px',
+  miniDrawerWidthDesktop: '56px',
   drawerWidthTablet: '320px',
   drawerHeightPhone: '250px',
   filterFormWidth: '160px',

--- a/src/reports/components/ReportsMenu.jsx
+++ b/src/reports/components/ReportsMenu.jsx
@@ -14,17 +14,27 @@ import RouteIcon from '@mui/icons-material/Route';
 import EventRepeatIcon from '@mui/icons-material/EventRepeat';
 import NotesIcon from '@mui/icons-material/Notes';
 import { Link, useLocation } from 'react-router-dom';
+import makeStyles from '@mui/styles/makeStyles';
 import { useTranslation } from '../../common/components/LocalizationProvider';
 import { useAdministrator, useRestriction } from '../../common/util/permissions';
 
+const useStyles = makeStyles({
+  menuItemText: {
+    whiteSpace: 'nowrap',
+  },
+});
+
 const MenuItem = ({
   title, link, icon, selected,
-}) => (
-  <ListItemButton key={link} component={Link} to={link} selected={selected}>
-    <ListItemIcon>{icon}</ListItemIcon>
-    <ListItemText primary={title} sx={{ whiteSpace: 'nowrap' }} />
-  </ListItemButton>
-);
+}) => {
+  const classes = useStyles();
+  return (
+    <ListItemButton key={link} component={Link} to={link} selected={selected}>
+      <ListItemIcon>{icon}</ListItemIcon>
+      <ListItemText primary={title} className={classes.menuItemText} />
+    </ListItemButton>
+  );
+};
 
 const ReportsMenu = () => {
   const t = useTranslation();

--- a/src/reports/components/ReportsMenu.jsx
+++ b/src/reports/components/ReportsMenu.jsx
@@ -22,7 +22,7 @@ const MenuItem = ({
 }) => (
   <ListItemButton key={link} component={Link} to={link} selected={selected}>
     <ListItemIcon>{icon}</ListItemIcon>
-    <ListItemText primary={title} />
+    <ListItemText primary={title} sx={{ whiteSpace: 'nowrap' }} />
   </ListItemButton>
 );
 

--- a/src/reports/components/ReportsMenu.jsx
+++ b/src/reports/components/ReportsMenu.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  Divider, List, ListItemButton, ListItemIcon, ListItemText,
-} from '@mui/material';
+import { Divider, List } from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import PauseCircleFilledIcon from '@mui/icons-material/PauseCircleFilled';
@@ -13,28 +11,10 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import RouteIcon from '@mui/icons-material/Route';
 import EventRepeatIcon from '@mui/icons-material/EventRepeat';
 import NotesIcon from '@mui/icons-material/Notes';
-import { Link, useLocation } from 'react-router-dom';
-import makeStyles from '@mui/styles/makeStyles';
+import { useLocation } from 'react-router-dom';
 import { useTranslation } from '../../common/components/LocalizationProvider';
 import { useAdministrator, useRestriction } from '../../common/util/permissions';
-
-const useStyles = makeStyles({
-  menuItemText: {
-    whiteSpace: 'nowrap',
-  },
-});
-
-const MenuItem = ({
-  title, link, icon, selected,
-}) => {
-  const classes = useStyles();
-  return (
-    <ListItemButton key={link} component={Link} to={link} selected={selected}>
-      <ListItemIcon>{icon}</ListItemIcon>
-      <ListItemText primary={title} className={classes.menuItemText} />
-    </ListItemButton>
-  );
-};
+import MenuItem from '../../common/components/MenuItem';
 
 const ReportsMenu = () => {
   const t = useTranslation();

--- a/src/settings/components/SettingsMenu.jsx
+++ b/src/settings/components/SettingsMenu.jsx
@@ -15,32 +15,14 @@ import PublishIcon from '@mui/icons-material/Publish';
 import SmartphoneIcon from '@mui/icons-material/Smartphone';
 import HelpIcon from '@mui/icons-material/Help';
 import CampaignIcon from '@mui/icons-material/Campaign';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import makeStyles from '@mui/styles/makeStyles';
 import { useTranslation } from '../../common/components/LocalizationProvider';
 import {
   useAdministrator, useManager, useRestriction,
 } from '../../common/util/permissions';
 import useFeatures from '../../common/util/useFeatures';
-
-const useStyles = makeStyles({
-  menuItemText: {
-    whiteSpace: 'nowrap',
-  },
-});
-
-const MenuItem = ({
-  title, link, icon, selected,
-}) => {
-  const classes = useStyles();
-  return (
-    <ListItemButton key={link} component={Link} to={link} selected={selected}>
-      <ListItemIcon>{icon}</ListItemIcon>
-      <ListItemText primary={title} className={classes.menuItemText} />
-    </ListItemButton>
-  );
-};
+import MenuItem from '../../common/components/MenuItem';
 
 const SettingsMenu = () => {
   const t = useTranslation();

--- a/src/settings/components/SettingsMenu.jsx
+++ b/src/settings/components/SettingsMenu.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Divider, List, ListItemButton, ListItemIcon, ListItemText,
+  Divider, List,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import CreateIcon from '@mui/icons-material/Create';

--- a/src/settings/components/SettingsMenu.jsx
+++ b/src/settings/components/SettingsMenu.jsx
@@ -17,20 +17,30 @@ import HelpIcon from '@mui/icons-material/Help';
 import CampaignIcon from '@mui/icons-material/Campaign';
 import { Link, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import makeStyles from '@mui/styles/makeStyles';
 import { useTranslation } from '../../common/components/LocalizationProvider';
 import {
   useAdministrator, useManager, useRestriction,
 } from '../../common/util/permissions';
 import useFeatures from '../../common/util/useFeatures';
 
+const useStyles = makeStyles({
+  menuItemText: {
+    whiteSpace: 'nowrap',
+  },
+});
+
 const MenuItem = ({
   title, link, icon, selected,
-}) => (
-  <ListItemButton key={link} component={Link} to={link} selected={selected}>
-    <ListItemIcon>{icon}</ListItemIcon>
-    <ListItemText primary={title} sx={{ whiteSpace: 'nowrap' }} />
-  </ListItemButton>
-);
+}) => {
+  const classes = useStyles();
+  return (
+    <ListItemButton key={link} component={Link} to={link} selected={selected}>
+      <ListItemIcon>{icon}</ListItemIcon>
+      <ListItemText primary={title} className={classes.menuItemText} />
+    </ListItemButton>
+  );
+};
 
 const SettingsMenu = () => {
   const t = useTranslation();

--- a/src/settings/components/SettingsMenu.jsx
+++ b/src/settings/components/SettingsMenu.jsx
@@ -28,7 +28,7 @@ const MenuItem = ({
 }) => (
   <ListItemButton key={link} component={Link} to={link} selected={selected}>
     <ListItemIcon>{icon}</ListItemIcon>
-    <ListItemText primary={title} />
+    <ListItemText primary={title} sx={{ whiteSpace: 'nowrap' }} />
   </ListItemButton>
 );
 


### PR DESCRIPTION
before:
<img width="994" alt="Captura de ecrã 2024-11-10, às 12 56 40" src="https://github.com/user-attachments/assets/cef9b05b-831b-4c86-b369-c93183641911">

after:
<img width="994" alt="Captura de ecrã 2024-11-10, às 12 56 56" src="https://github.com/user-attachments/assets/3762b4f8-76ed-4ae7-8f62-fb88c2a26fbf">

before:
<img width="989" alt="Captura de ecrã 2024-11-10, às 13 25 00" src="https://github.com/user-attachments/assets/554c45a4-29f8-4d8e-af6f-9ddec4efbf77">

after:
<img width="989" alt="Captura de ecrã 2024-11-10, às 13 24 49" src="https://github.com/user-attachments/assets/54efad34-24e7-4002-be91-5d3ec2bb5fd1">

before:
<img width="936" alt="Captura de ecrã 2024-11-10, às 13 27 34" src="https://github.com/user-attachments/assets/bf29786e-6f3b-4ce8-9c37-eeb3ae5d09de">

after:
<img width="936" alt="Captura de ecrã 2024-11-10, às 13 27 18" src="https://github.com/user-attachments/assets/2146bb25-504b-4fbc-aaf1-a8ac41012746">

<img width="936" alt="Captura de ecrã 2024-11-10, às 13 26 45" src="https://github.com/user-attachments/assets/ee0de1fb-41ea-4f4b-8f1b-93f23bf50b43">

