### PR TITLE
fix: Better StatusCard spacing on a long edge case.

### DIFF
--- a/src/common/components/StatusCard.jsx
+++ b/src/common/components/StatusCard.jsx
@@ -73,6 +73,9 @@ const useStyles = makeStyles((theme) => ({
       paddingLeft: 0,
       paddingRight: 0,
     },
+    '& .MuiTableCell-sizeSmall:first-child': {
+      paddingRight: theme.spacing(1),
+    },
   },
   cell: {
     borderBottom: 'none',


### PR DESCRIPTION
Hi,

as this has been bothering me for quite some time. An edge case but happens quite a lot to me. Best explained in pictures:
Before
![Screenshot From 2024-11-26 20-17-56](https://github.com/user-attachments/assets/eb1986bb-9c9d-4f34-8bf7-186ad7c36a71)

After:
![Screenshot From 2024-11-26 20-17-31](https://github.com/user-attachments/assets/2aa524b8-b394-4d6a-a25c-31302d3142cb)

I applied the standard padding to the first cell only, so that the second one can still fill in fully.
