### PR TITLE
Add position id as an attribute to route reports

### DIFF
--- a/src/reports/RouteReportPage.jsx
+++ b/src/reports/RouteReportPage.jsx
@@ -140,7 +140,7 @@ const RouteReportPage = () => {
             </TableHead>
             <TableBody>
               {!loading ? items.slice(0, 4000).map((item) => (
-                <TableRow key={item.id}>
+                <TableRow key={item.id} attr-id={item.id}>
                   <TableCell className={classes.columnAction} padding="none">
                     {selectedItem === item ? (
                       <IconButton size="small" onClick={() => setSelectedItem(null)}>


### PR DESCRIPTION
It can be useful in combination with `DELETE /api/positions/:id` from https://github.com/traccar/traccar/pull/5537

This may also make sense on other table elements (there are a few) but I personally have no usecase for doing that.