### PR TITLE
Add position deletion button to route report

### DIFF
--- a/src/reports/RouteReportPage.jsx
+++ b/src/reports/RouteReportPage.jsx
@@ -24,6 +24,8 @@ import MapCamera from '../map/MapCamera';
 import MapGeofence from '../map/MapGeofence';
 import scheduleReport from './common/scheduleReport';
 import MapScale from '../map/MapScale';
+import { useRestriction } from '../common/util/permissions';
+import CollectionActions from '../settings/components/CollectionActions';
 
 const RouteReportPage = () => {
   const navigate = useNavigate();
@@ -33,6 +35,7 @@ const RouteReportPage = () => {
   const positionAttributes = usePositionAttributes(t);
 
   const devices = useSelector((state) => state.devices.items);
+  const readonly = useRestriction('readonly');
 
   const [available, setAvailable] = useState([]);
   const [columns, setColumns] = useState(['fixTime', 'latitude', 'longitude', 'speed', 'address']);
@@ -136,6 +139,7 @@ const RouteReportPage = () => {
                 <TableCell className={classes.columnAction} />
                 <TableCell>{t('sharedDevice')}</TableCell>
                 {columns.map((key) => (<TableCell key={key}>{positionAttributes[key]?.name || key}</TableCell>))}
+                <TableCell className={classes.columnAction} />
               </TableRow>
             </TableHead>
             <TableBody>
@@ -162,6 +166,17 @@ const RouteReportPage = () => {
                       />
                     </TableCell>
                   ))}
+                  <TableCell className={classes.actionCellPadding}>
+                    <CollectionActions
+                      itemId={item.id}
+                      endpoint="positions"
+                      readonly={readonly}
+                      setTimestamp={() => {
+                        // NOTE: Gets called when an item was removed
+                        setItems(items.filter((position) => position.id !== item.id));
+                      }}
+                    />
+                  </TableCell>
                 </TableRow>
               )) : (<TableShimmer columns={columns.length + 2} startAction />)}
             </TableBody>

--- a/src/reports/common/useReportStyles.js
+++ b/src/reports/common/useReportStyles.js
@@ -46,4 +46,10 @@ export default makeStyles((theme) => ({
     flexGrow: 1,
     overflow: 'hidden',
   },
+  actionCellPadding: {
+    '&.MuiTableCell-body': {
+      paddingTop: 0,
+      paddingBottom: 0,
+    },
+  },
 }));

--- a/src/settings/components/CollectionActions.jsx
+++ b/src/settings/components/CollectionActions.jsx
@@ -65,7 +65,7 @@ const CollectionActions = ({
             ))}
             {!readonly && (
               <>
-                <MenuItem onClick={handleEdit}>{t('sharedEdit')}</MenuItem>
+                {editPath && <MenuItem onClick={handleEdit}>{t('sharedEdit')}</MenuItem>}
                 <MenuItem onClick={handleRemove}>{t('sharedRemove')}</MenuItem>
               </>
             )}
@@ -82,11 +82,13 @@ const CollectionActions = ({
           ))}
           {!readonly && (
             <>
-              <Tooltip title={t('sharedEdit')}>
-                <IconButton size="small" onClick={handleEdit}>
-                  <EditIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
+              {editPath && (
+                <Tooltip title={t('sharedEdit')}>
+                  <IconButton size="small" onClick={handleEdit}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
               <Tooltip title={t('sharedRemove')}>
                 <IconButton size="small" onClick={handleRemove}>
                   <DeleteIcon fontSize="small" />


### PR DESCRIPTION
Use this to delete wrong data.


Followup to https://github.com/traccar/traccar-web/pull/1347. It uses the newly added endpoint to delete a position added in https://github.com/traccar/traccar/pull/5537

I placed the delete icon at the very end of the table. I feel like putting it next to the gps icon invites users to accidentally click on it (even if it has a confirmation prompt).

Again, very much out of my comfort zone with this (React). I largely followed how other parts of the codebase do it, like `ScheduledPage.jsx`.

[Screencast_20250401_173110.webm](https://github.com/user-attachments/assets/d7c47f8c-818a-4130-a1d7-3f6ea0497889)