### PR TITLE
Add an icon on the trip report to view the replay

### DIFF
--- a/src/other/ReplayPage.jsx
+++ b/src/other/ReplayPage.jsx
@@ -12,7 +12,7 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PauseIcon from '@mui/icons-material/Pause';
 import FastForwardIcon from '@mui/icons-material/FastForward';
 import FastRewindIcon from '@mui/icons-material/FastRewind';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import MapView from '../map/core/MapView';
 import MapRoutePath from '../map/MapRoutePath';
@@ -82,6 +82,8 @@ const ReplayPage = () => {
   const navigate = useNavigate();
   const timerRef = useRef();
 
+  const locationState = useLocation().state;
+
   const defaultDeviceId = useSelector((state) => state.devices.selectedId);
 
   const [positions, setPositions] = useState([]);
@@ -93,6 +95,7 @@ const ReplayPage = () => {
   const [expanded, setExpanded] = useState(true);
   const [playing, setPlaying] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [initialState, setInitialState] = useState(locationState);
 
   const deviceName = useSelector((state) => {
     if (selectedDeviceId) {
@@ -133,6 +136,7 @@ const ReplayPage = () => {
 
   const handleSubmit = useCatch(async ({ deviceId, from, to }) => {
     setLoading(true);
+    setInitialState(null);
     setSelectedDeviceId(deviceId);
     setFrom(from);
     setTo(to);
@@ -219,7 +223,7 @@ const ReplayPage = () => {
               </div>
             </>
           ) : (
-            <ReportFilter handleSubmit={handleSubmit} fullScreen showOnly loading={loading} />
+            <ReportFilter handleSubmit={handleSubmit} fullScreen showOnly loading={loading} initialState={initialState} />
           )}
         </Paper>
       </div>

--- a/src/reports/TripReportPage.jsx
+++ b/src/reports/TripReportPage.jsx
@@ -5,10 +5,11 @@ import {
 } from '@mui/material';
 import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 import LocationSearchingIcon from '@mui/icons-material/LocationSearching';
+import RouteIcon from '@mui/icons-material/Route';
 import {
   formatDistance, formatSpeed, formatVolume, formatTime, formatNumericHours,
 } from '../common/util/formatter';
-import ReportFilter from './components/ReportFilter';
+import ReportFilter, { replayReportLocationState } from './components/ReportFilter';
 import { useAttributePreference } from '../common/util/preferences';
 import { useTranslation } from '../common/components/LocalizationProvider';
 import PageLayout from '../common/components/PageLayout';
@@ -119,6 +120,16 @@ const TripReportPage = () => {
     }
   });
 
+  const navigateToReplay = (item) => {
+    navigate('/replay', {
+      state: replayReportLocationState({
+        from: item.startTime,
+        to: item.endTime,
+        deviceId: item.deviceId,
+      }),
+    });
+  };
+
   const handleSchedule = useCatch(async (deviceIds, groupIds, report) => {
     report.type = 'trips';
     const error = await scheduleReport(deviceIds, groupIds, report);
@@ -183,6 +194,7 @@ const TripReportPage = () => {
             <TableHead>
               <TableRow>
                 <TableCell className={classes.columnAction} />
+                <TableCell className={classes.columnAction} />
                 {columns.map((key) => (<TableCell key={key}>{t(columnsMap.get(key))}</TableCell>))}
               </TableRow>
             </TableHead>
@@ -199,6 +211,11 @@ const TripReportPage = () => {
                         <LocationSearchingIcon fontSize="small" />
                       </IconButton>
                     )}
+                  </TableCell>
+                  <TableCell className={classes.columnAction} padding="none">
+                    <IconButton size="small" onClick={() => navigateToReplay(item)}>
+                      <RouteIcon fontSize="small" />
+                    </IconButton>
                   </TableCell>
                   {columns.map((key) => (
                     <TableCell key={key}>


### PR DESCRIPTION
It uses query parameters to carry the state, so when you navigate back you still have your previous
timerange selected.

There's logic that when a query parameter `deviceId` is present, it navigates back to the root page. I've changed that to only apply on the root page itself, because I'd like to use a parameter named like that on a different page.

I also tried integrating the replay-style map directly into the trips page but that is above what I'm capable of.

[Screencast_20250402_211313.webm](https://github.com/user-attachments/assets/d5c716c6-f8da-4267-94ec-a041bc3e9d16)
