### PR TITLE
Scroll route position into view when opening on map

### DIFF
--- a/src/reports/RouteReportPage.jsx
+++ b/src/reports/RouteReportPage.jsx
@@ -1,4 +1,6 @@
-import React, { Fragment, useCallback, useState } from 'react';
+import React, {
+  Fragment, useCallback, useEffect, useRef, useState,
+} from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -42,6 +44,14 @@ const RouteReportPage = () => {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
+
+  const selectedIcon = useRef();
+
+  useEffect(() => {
+    if (selectedIcon.current) {
+      selectedIcon.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }, [selectedIcon.current]);
 
   const onMapPointClick = useCallback((positionId) => {
     setSelectedItem(items.find((it) => it.id === positionId));
@@ -147,7 +157,7 @@ const RouteReportPage = () => {
                 <TableRow key={item.id}>
                   <TableCell className={classes.columnAction} padding="none">
                     {selectedItem === item ? (
-                      <IconButton size="small" onClick={() => setSelectedItem(null)}>
+                      <IconButton size="small" onClick={() => setSelectedItem(null)} ref={selectedIcon}>
                         <GpsFixedIcon fontSize="small" />
                       </IconButton>
                     ) : (


### PR DESCRIPTION
When the list is large, it's very difficult to scroll to the point that was just openend. This just does this automatically for you.

Performance on this page is not that good as you can see in the video, but it was that way before already. I didn't notice a difference performance-wise before/after my change.

https://github.com/user-attachments/assets/6bc3d644-b293-4554-9863-b0718ab76ed5

