### PR TITLE
Decouple display locale from date locale

### DIFF
--- a/src/common/components/LocalizationProvider.jsx
+++ b/src/common/components/LocalizationProvider.jsx
@@ -144,6 +144,19 @@ const getDefaultLanguage = () => {
   return 'en';
 };
 
+const getDefaultDateLocale = () => {
+  let locale;
+  if (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat !== 'undefined') {
+    locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  } else {
+    locale = getDefaultLanguage();
+  }
+  if (locale.length > 2) {
+    locale = `${locale.slice(0, 2)}-${locale.slice(-2).toLowerCase()}`;
+  }
+  return locale;
+};
+
 const LocalizationContext = createContext({
   languages,
   language: 'en',
@@ -154,18 +167,13 @@ export const LocalizationProvider = ({ children }) => {
   const [language, setLanguage] = usePersistedState('language', getDefaultLanguage());
   const direction = /^(ar|he|fa)$/.test(language) ? 'rtl' : 'ltr';
 
+  dayjs.locale(getDefaultDateLocale());
+
   const value = useMemo(() => ({ languages, language, setLanguage, direction }), [languages, language, setLanguage, direction]);
 
   useEffect(() => {
-    let selected;
-    if (language.length > 2) {
-      selected = `${language.slice(0, 2)}-${language.slice(-2).toLowerCase()}`;
-    } else {
-      selected = language;
-    }
-    dayjs.locale(selected);
     document.dir = direction;
-  }, [language, direction]);
+  }, [direction]);
 
   return (
     <LocalizationContext.Provider value={value}>


### PR DESCRIPTION
I have my browser display content in english by default, so the locale for dates also becomes en. However, regardless of that setting my default locale for dates is de, which among other things causes weeks to start on monday (not sunday).

It aligns it to which locale the browser renders date input fields (am/pm 12h vs 24h, DDMMYYYY vs MMDDYYYY, etc.). These are already in the correct locale (display locale != date locale)

Browsers don't offer to configure display and date locales separately. Rather such settings are delegated to the operating system. On Windows that would be "Time and Language / Language and Region / Regional Format).

I believe this affects the reports only (primarily "This Week"/"Previous Week", other places explicitly overwrite the locale to en.

`formatTime` already uses the correct locale because it works through `toLocaleDateString` under the hood. It's a build-in browser method that chooses the appropriate locale automatically.