### PR TITLE
Fix Emulator not working with https.

### DIFF
--- a/src/other/EmulatorPage.jsx
+++ b/src/other/EmulatorPage.jsx
@@ -72,13 +72,13 @@ const EmulatorPage = () => {
     if (deviceId) {
       let response;
       if (window.location.protocol === 'https:') {
-        const formData = new FormData();
-        formData.append('id', devices[deviceId].uniqueId);
-        formData.append('lat', latitude);
-        formData.append('lon', longitude);
+        const params = new URLSearchParams();
+        params.append('id', devices[deviceId].uniqueId);
+        params.append('lat', latitude);
+        params.append('lon', longitude);
         response = await fetch(window.location.origin, {
           method: 'POST',
-          body: formData,
+          body: params.toString(),
         });
       } else {
         const params = new URLSearchParams();


### PR DESCRIPTION
After a whole day trying to get emulator working behind nginx reverse proxy I gave up and patch js file.

I make it because POST requests has sent to OSMAND port (proxied or not) failed with 400 error when 'Content-Type': 'multipart/form-data' but with 'Content-Type': 'application/x-www-form-urlencoded' all is working smoothly.

Please fix it in the next release.