### PR TITLE
Fix emulator Toolbar in phone sizes

### DIFF
--- a/src/other/EmulatorPage.jsx
+++ b/src/other/EmulatorPage.jsx
@@ -101,7 +101,7 @@ const EmulatorPage = () => {
       <div className={classes.content}>
         <Drawer
           className={classes.drawer}
-          anchor={isPhone ? 'bottom' : 'left'}
+          anchor={isPhone ? 'top' : 'left'}
           variant="permanent"
           classes={{ paper: classes.drawerPaper }}
         >


### PR DESCRIPTION
Now toolbar is sticky to top, not bottom. So now it's correctly working with phone sizes.

Before:

<img width="556" alt="image" src="https://github.com/user-attachments/assets/539030b3-0a49-4216-bd16-494db0f5e218" />

After:

<img width="552" alt="Screenshot 2025-05-05 at 12 16 43" src="https://github.com/user-attachments/assets/0b0f654d-1e81-4026-93ac-15af32ef47c2" />
