### PR TITLE
Use datetime-local input, support clear button, show expiration time with minutes

### DIFF
--- a/src/common/util/formatter.js
+++ b/src/common/util/formatter.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
+import utc from 'dayjs/plugin/utc';
 
 import {
   altitudeFromMeters,
@@ -18,6 +19,7 @@ import { prefixString } from './stringUtils';
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
 dayjs.extend(localizedFormat);
+dayjs.extend(utc);
 
 export const formatBoolean = (value, t) => (value ? t('sharedYes') : t('sharedNo'));
 
@@ -30,6 +32,22 @@ export const formatTemperature = (value) => `${value.toFixed(1)}°C`;
 export const formatVoltage = (value, t) => `${value.toFixed(2)} ${t('sharedVoltAbbreviation')}`;
 
 export const formatConsumption = (value, t) => `${value.toFixed(2)} ${t('sharedLiterPerHourAbbreviation')}`;
+
+export const formatLocalTimeToUTC = (value) => {
+  if (value) {
+    return dayjs(value).utc().toISOString();
+  }
+
+  return '';
+}
+
+export const formatDateTimeLocalInput = (value) => {
+  if (value) {
+    return dayjs.utc(value).local().format('YYYY-MM-DDTHH:mm');
+  }
+
+  return '';
+}
 
 export const formatTime = (value, format) => {
   if (value) {

--- a/src/common/util/formatter.js
+++ b/src/common/util/formatter.js
@@ -33,14 +33,6 @@ export const formatVoltage = (value, t) => `${value.toFixed(2)} ${t('sharedVoltA
 
 export const formatConsumption = (value, t) => `${value.toFixed(2)} ${t('sharedLiterPerHourAbbreviation')}`;
 
-export const formatLocalTimeToUTC = (value) => {
-  if (value) {
-    return dayjs(value).utc().toISOString();
-  }
-
-  return '';
-}
-
 export const formatDateTimeLocalInput = (value) => {
   if (value) {
     return dayjs.utc(value).local().format('YYYY-MM-DDTHH:mm');

--- a/src/settings/DevicePage.jsx
+++ b/src/settings/DevicePage.jsx
@@ -24,6 +24,7 @@ import { useCatch } from '../reactHelper';
 import useQuery from '../common/util/useQuery';
 import useSettingsStyles from './common/useSettingsStyles';
 import QrCodeDialog from '../common/components/QrCodeDialog';
+import { formatDateTimeLocalInput, formatLocalTimeToUTC } from '../common/util/formatter';
 
 const DevicePage = () => {
   const { classes } = useSettingsStyles();
@@ -139,11 +140,13 @@ const DevicePage = () => {
               />
               <TextField
                 label={t('userExpirationTime')}
-                type="date"
-                value={item.expirationTime ? item.expirationTime.split('T')[0] : '2099-01-01'}
+                type="datetime-local"
+                value={item.expirationTime ? formatDateTimeLocalInput(item.expirationTime) : '2099-01-01T00:00'}
                 onChange={(e) => {
                   if (e.target.value) {
-                    setItem({ ...item, expirationTime: new Date(e.target.value).toISOString() });
+                    setItem({ ...item, expirationTime: formatLocalTimeToUTC(e.target.value) });
+                  } else {
+                    setItem({ ...item, expirationTime: null });
                   }
                 }}
                 disabled={!admin}

--- a/src/settings/DevicePage.jsx
+++ b/src/settings/DevicePage.jsx
@@ -11,7 +11,6 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { MuiFileInput } from 'mui-file-input';
-import dayjs from 'dayjs';
 import EditItemView from './components/EditItemView';
 import EditAttributesAccordion from './components/EditAttributesAccordion';
 import SelectField from '../common/components/SelectField';
@@ -145,7 +144,7 @@ const DevicePage = () => {
                 value={item.expirationTime ? formatDateTimeLocalInput(item.expirationTime) : '2099-01-01T00:00'}
                 onChange={(e) => {
                   if (e.target.value) {
-                    setItem({ ...item, expirationTime: dayjs(e.target.value).format() });
+                    setItem({ ...item, expirationTime: new Date(e.target.value).toISOString() });
                   } else {
                     setItem({ ...item, expirationTime: null });
                   }

--- a/src/settings/DevicePage.jsx
+++ b/src/settings/DevicePage.jsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { MuiFileInput } from 'mui-file-input';
+import dayjs from 'dayjs';
 import EditItemView from './components/EditItemView';
 import EditAttributesAccordion from './components/EditAttributesAccordion';
 import SelectField from '../common/components/SelectField';
@@ -24,7 +25,7 @@ import { useCatch } from '../reactHelper';
 import useQuery from '../common/util/useQuery';
 import useSettingsStyles from './common/useSettingsStyles';
 import QrCodeDialog from '../common/components/QrCodeDialog';
-import { formatDateTimeLocalInput, formatLocalTimeToUTC } from '../common/util/formatter';
+import { formatDateTimeLocalInput } from '../common/util/formatter';
 
 const DevicePage = () => {
   const { classes } = useSettingsStyles();
@@ -144,7 +145,7 @@ const DevicePage = () => {
                 value={item.expirationTime ? formatDateTimeLocalInput(item.expirationTime) : '2099-01-01T00:00'}
                 onChange={(e) => {
                   if (e.target.value) {
-                    setItem({ ...item, expirationTime: formatLocalTimeToUTC(e.target.value) });
+                    setItem({ ...item, expirationTime: dayjs(e.target.value).format() });
                   } else {
                     setItem({ ...item, expirationTime: null });
                   }

--- a/src/settings/DevicesPage.jsx
+++ b/src/settings/DevicesPage.jsx
@@ -87,7 +87,7 @@ const DevicesPage = () => {
               <TableCell>{item.phone}</TableCell>
               <TableCell>{item.model}</TableCell>
               <TableCell>{item.contact}</TableCell>
-              <TableCell>{formatTime(item.expirationTime, 'date')}</TableCell>
+              <TableCell>{formatTime(item.expirationTime, 'minutes')}</TableCell>
               {manager && <TableCell><DeviceUsersValue deviceId={item.id} /></TableCell>}
               <TableCell className={classes.columnAction} padding="none">
                 <CollectionActions

--- a/src/settings/UserPage.jsx
+++ b/src/settings/UserPage.jsx
@@ -23,6 +23,7 @@ import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import CachedIcon from '@mui/icons-material/Cached';
 import CloseIcon from '@mui/icons-material/Close';
 import { useDispatch, useSelector } from 'react-redux';
+import dayjs from 'dayjs';
 import EditItemView from './components/EditItemView';
 import EditAttributesAccordion from './components/EditAttributesAccordion';
 import { useTranslation } from '../common/components/LocalizationProvider';
@@ -37,7 +38,7 @@ import { useCatch } from '../reactHelper';
 import useMapStyles from '../map/core/useMapStyles';
 import { map } from '../map/core/MapView';
 import useSettingsStyles from './common/useSettingsStyles';
-import { formatDateTimeLocalInput, formatLocalTimeToUTC } from '../common/util/formatter';
+import { formatDateTimeLocalInput } from '../common/util/formatter';
 
 const UserPage = () => {
   const { classes } = useSettingsStyles();
@@ -327,7 +328,7 @@ const UserPage = () => {
                 value={item.expirationTime ? formatDateTimeLocalInput(item.expirationTime) : '2099-01-01T00:00'}
                 onChange={(e) => {
                   if (e.target.value) {
-                    setItem({ ...item, expirationTime: formatLocalTimeToUTC(e.target.value) });
+                    setItem({ ...item, expirationTime: dayjs(e.target.value).format() });
                   } else {
                     setItem({ ...item, expirationTime: null });
                   }

--- a/src/settings/UserPage.jsx
+++ b/src/settings/UserPage.jsx
@@ -23,7 +23,6 @@ import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import CachedIcon from '@mui/icons-material/Cached';
 import CloseIcon from '@mui/icons-material/Close';
 import { useDispatch, useSelector } from 'react-redux';
-import dayjs from 'dayjs';
 import EditItemView from './components/EditItemView';
 import EditAttributesAccordion from './components/EditAttributesAccordion';
 import { useTranslation } from '../common/components/LocalizationProvider';
@@ -328,7 +327,7 @@ const UserPage = () => {
                 value={item.expirationTime ? formatDateTimeLocalInput(item.expirationTime) : '2099-01-01T00:00'}
                 onChange={(e) => {
                   if (e.target.value) {
-                    setItem({ ...item, expirationTime: dayjs(e.target.value).format() });
+                    setItem({ ...item, expirationTime: new Date(e.target.value).toISOString() });
                   } else {
                     setItem({ ...item, expirationTime: null });
                   }

--- a/src/settings/UserPage.jsx
+++ b/src/settings/UserPage.jsx
@@ -37,6 +37,7 @@ import { useCatch } from '../reactHelper';
 import useMapStyles from '../map/core/useMapStyles';
 import { map } from '../map/core/MapView';
 import useSettingsStyles from './common/useSettingsStyles';
+import { formatDateTimeLocalInput, formatLocalTimeToUTC } from '../common/util/formatter';
 
 const UserPage = () => {
   const { classes } = useSettingsStyles();
@@ -322,11 +323,13 @@ const UserPage = () => {
             <AccordionDetails className={classes.details}>
               <TextField
                 label={t('userExpirationTime')}
-                type="date"
-                value={item.expirationTime ? item.expirationTime.split('T')[0] : '2099-01-01'}
+                type="datetime-local"
+                value={item.expirationTime ? formatDateTimeLocalInput(item.expirationTime) : '2099-01-01T00:00'}
                 onChange={(e) => {
                   if (e.target.value) {
-                    setItem({ ...item, expirationTime: new Date(e.target.value).toISOString() });
+                    setItem({ ...item, expirationTime: formatLocalTimeToUTC(e.target.value) });
+                  } else {
+                    setItem({ ...item, expirationTime: null });
                   }
                 }}
                 disabled={!manager}

--- a/src/settings/UsersPage.jsx
+++ b/src/settings/UsersPage.jsx
@@ -88,7 +88,7 @@ const UsersPage = () => {
               <TableCell>{item.email}</TableCell>
               <TableCell>{formatBoolean(item.administrator, t)}</TableCell>
               <TableCell>{formatBoolean(item.disabled, t)}</TableCell>
-              <TableCell>{formatTime(item.expirationTime, 'date')}</TableCell>
+              <TableCell>{formatTime(item.expirationTime, 'minutes')}</TableCell>
               <TableCell className={classes.columnAction} padding="none">
                 <CollectionActions
                   itemId={item.id}


### PR DESCRIPTION
Problem explanation:

- My local time zone is GMT-7.  
- When selecting an expiration date: `07/08/2025 `
- The database stores it as: `2025-07-08 00:00:00`
- However, when displaying expirationTime using `formatTime(item.expirationTime, 'date')`, it appears as `07/07/2025` (one day earlier).  
- This happens because the date is not stored in UTC, and converting to local time shifts the date.

Solution:
~~Store the date always in **UTC** to avoid timezone-related mismatches.~~
Change input date to datetime-local.

- Change the input to datetime-local to support hours and minutes.
  PC:
  ![image](https://github.com/user-attachments/assets/15ca879c-13ac-4adb-8a19-d71ebfeb39f9)

  Android:
  ![image](https://github.com/user-attachments/assets/a386a0e1-4fb6-45e1-8b6a-5d1ecb457e30)

Bonus:
- Add support for the Clear button, which now properly set the field to `01/01/2099 12:00 AM` and value to `null`.  
  ![image](https://github.com/user-attachments/assets/7718345e-4230-4776-b771-f3818203e836)

- Show the expiration date with hours and minutes in the table.  
  ![image](https://github.com/user-attachments/assets/3f71b40f-12c7-4fc4-981a-8e87cdcb36b9)