### PR TITLE
Adding dynamic icons and Address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6490,19 +6490,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",

--- a/src/common/util/deviceCategories.js
+++ b/src/common/util/deviceCategories.js
@@ -19,4 +19,5 @@ export default [
   'truck',
   'van',
   'scooter',
+  'dynamic', //adding dynamic category
 ];

--- a/src/main/DeviceRow.jsx
+++ b/src/main/DeviceRow.jsx
@@ -67,6 +67,11 @@ const DeviceRow = ({ data, index, style }) => {
   const devicePrimary = useAttributePreference('devicePrimary', 'name');
   const deviceSecondary = useAttributePreference('deviceSecondary', '');
 
+  let dynamicStatus = item.category; //creating a variable for dynamic Status
+  if (item.category === 'dynamic') {
+    dynamicStatus = position ? position.attributes.dynamicStatus : 'default';
+  }
+
   const secondaryText = () => {
     let status;
     if (item.status === 'online' || !item.lastUpdate) {
@@ -76,7 +81,8 @@ const DeviceRow = ({ data, index, style }) => {
     }
     return (
       <>
-        {deviceSecondary && item[deviceSecondary] && `${item[deviceSecondary]} • `}
+        {/* displaying address as secondary text if available */}
+        {deviceSecondary && position && (item[deviceSecondary] || position[deviceSecondary]) && `${item[deviceSecondary] || position[deviceSecondary].slice(0, 22)} • `}
         <span className={classes[getStatusColor(item.status)]}>{status}</span>
       </>
     );
@@ -93,7 +99,8 @@ const DeviceRow = ({ data, index, style }) => {
       >
         <ListItemAvatar>
           <Avatar>
-            <img className={classes.icon} src={mapIcons[mapIconKey(item.category)]} alt="" />
+            {/*displaying dynamic icon*/}
+            <img className={classes.icon} src={mapIcons[mapIconKey(dynamicStatus)]} alt="" />
           </Avatar>
         </ListItemAvatar>
         <ListItemText
@@ -140,10 +147,10 @@ const DeviceRow = ({ data, index, style }) => {
                       ? (<BatteryCharging60Icon fontSize="small" className={classes.warning} />)
                       : (<Battery60Icon fontSize="small" className={classes.warning} />)
                   )) || (
-                    position.attributes.charge
-                      ? (<BatteryCharging20Icon fontSize="small" className={classes.error} />)
-                      : (<Battery20Icon fontSize="small" className={classes.error} />)
-                  )}
+                      position.attributes.charge
+                        ? (<BatteryCharging20Icon fontSize="small" className={classes.error} />)
+                        : (<Battery20Icon fontSize="small" className={classes.error} />)
+                    )}
                 </IconButton>
               </Tooltip>
             )}

--- a/src/main/MainToolbar.jsx
+++ b/src/main/MainToolbar.jsx
@@ -72,6 +72,7 @@ const MainToolbar = ({
         onBlur={() => setDevicesAnchorEl(null)}
         endAdornment={(
           <InputAdornment position="end">
+            {filteredDevices.length} {/* added total number of devices*/}
             <IconButton size="small" edge="end" onClick={() => setFilterAnchorEl(inputRef.current)}>
               <Badge color="info" variant="dot" invisible={!filter.statuses.length && !filter.groups.length}>
                 <TuneIcon fontSize="small" />

--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -43,10 +43,11 @@ const MapPositions = ({ positions, onMapClick, onMarkerClick, showStatus, select
       deviceId: position.deviceId,
       name: device.name,
       fixTime: formatTime(position.fixTime, 'seconds'),
-      category: mapIconKey(device.category),
+      category: device.category === 'dynamic' ? mapIconKey(position.attributes.dynamicStatus) : mapIconKey(device.category), // Map icon depending on device category
       color: showStatus ? position.attributes.color || getStatusColor(device.status) : 'neutral',
       rotation: position.course,
       direction: showDirection,
+      dynamicDirection: (position.attributes.dynamicStatus === 'moving' && device.category === 'dynamic'), //show direction for the moving icone and hide the direction layer
     };
   };
 
@@ -108,6 +109,12 @@ const MapPositions = ({ positions, onMapClick, onMarkerClick, showStatus, select
           'icon-image': '{category}-{color}',
           'icon-size': iconScale,
           'icon-allow-overlap': true,
+          'icon-rotate': [
+            'case',
+            ['==', ['get', 'dynamicDirection'], true],
+            ['get', 'rotation'],
+            0
+          ],
           'text-field': `{${titleField || 'name'}}`,
           'text-allow-overlap': true,
           'text-anchor': 'bottom',
@@ -128,6 +135,7 @@ const MapPositions = ({ positions, onMapClick, onMarkerClick, showStatus, select
           'all',
           ['!has', 'point_count'],
           ['==', 'direction', true],
+          ['==', 'dynamicDirection', false], // do not show direction for the dynamic category
         ],
         layout: {
           'icon-image': 'direction',

--- a/src/map/core/preloadImages.js
+++ b/src/map/core/preloadImages.js
@@ -26,6 +26,9 @@ import trainSvg from '../../resources/images/icon/train.svg';
 import tramSvg from '../../resources/images/icon/tram.svg';
 import truckSvg from '../../resources/images/icon/truck.svg';
 import vanSvg from '../../resources/images/icon/van.svg';
+import parkedSvg from '../../resources/images/icon/parked.svg'
+import movingSvg from '../../resources/images/icon/moving.svg'
+import idlingSvg from '../../resources/images/icon/idling.svg'
 
 export const mapIcons = {
   animal: animalSvg,
@@ -50,6 +53,9 @@ export const mapIcons = {
   tram: tramSvg,
   truck: truckSvg,
   van: vanSvg,
+  parked: parkedSvg, //adding the new icons
+  moving: movingSvg,
+  idling: idlingSvg,
 };
 
 export const mapIconKey = (category) => {

--- a/src/resources/images/icon/idling.svg
+++ b/src/resources/images/icon/idling.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' height='24' width='24' viewBox='0 0 24 24' fill='none'><!-- Left pause bar --><rect x='6.5' y='5' width='4' height='14' fill='#5f6368'/><!-- Right pause bar --><rect x='13.5' y='5' width='4' height='14' fill='#5f6368'/></svg>

--- a/src/resources/images/icon/moving.svg
+++ b/src/resources/images/icon/moving.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' height='24px' width='24px' viewBox='0 0 24 24' fill='#5f6368'><!-- Thicker Tail --><line x1='12' y1='18' x2='12' y2='10' stroke='#5f6368' stroke-width='3'/><!-- Thicker Arrowhead --><polygon points='5,10 12,3 19,10' fill='#5f6368'/></svg>

--- a/src/resources/images/icon/parked.svg
+++ b/src/resources/images/icon/parked.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' height='24px' width='24px' viewBox='0 0 24 24' fill='none'><rect x='4' y='4' width='16' height='16' stroke='#5f6368' stroke-width='3' fill='#5f6368'/></svg>

--- a/src/resources/l10n/ar.json
+++ b/src/resources/l10n/ar.json
@@ -214,6 +214,7 @@
     "deviceIdentifier": "المعرف",
     "deviceModel": "الطراز",
     "deviceContact": "بيانات التواصل",
+    "deviceAddress": "العنوان",
     "deviceCategory": "الصنف",
     "deviceLastUpdate": "آخر تحديث",
     "deviceCommand": "أمر",
@@ -618,6 +619,7 @@
     "categoryTruck": "شاحنة",
     "categoryVan": "نقل",
     "categoryScooter": "سكوتر",
+    "categoryDynamic": "ديناميكي",
     "maintenanceStart": "بداية",
     "maintenancePeriod": "فترة"
 }

--- a/src/resources/l10n/en.json
+++ b/src/resources/l10n/en.json
@@ -217,6 +217,7 @@
     "deviceIdentifier": "Identifier",
     "deviceModel": "Model",
     "deviceContact": "Contact",
+    "deviceAddress": "Address",
     "deviceCategory": "Category",
     "deviceLastUpdate": "Last Update",
     "deviceCommand": "Command",
@@ -623,6 +624,7 @@
     "categoryTruck": "Truck",
     "categoryVan": "Van",
     "categoryScooter": "Scooter",
+    "categoryDynamic": "Dynamic",
     "maintenanceStart": "Start",
     "maintenancePeriod": "Period"
 }

--- a/src/resources/l10n/fr.json
+++ b/src/resources/l10n/fr.json
@@ -214,6 +214,7 @@
     "deviceIdentifier": "Identifiant",
     "deviceModel": "Modèle",
     "deviceContact": "Contact",
+    "deviceAddress": "Adresse",
     "deviceCategory": "Catégorie",
     "deviceLastUpdate": "Dernière mise à jour",
     "deviceCommand": "Commande",
@@ -618,6 +619,7 @@
     "categoryTruck": "Camion",
     "categoryVan": "Van",
     "categoryScooter": "Scooter",
+    "categoryDynamic": "Dynamique",
     "maintenanceStart": "Départ",
     "maintenancePeriod": "Période"
 }

--- a/src/settings/PreferencesPage.jsx
+++ b/src/settings/PreferencesPage.jsx
@@ -28,6 +28,7 @@ const deviceFields = [
   { id: 'phone', name: 'sharedPhone' },
   { id: 'model', name: 'deviceModel' },
   { id: 'contact', name: 'deviceContact' },
+  { id: 'address', name: 'deviceAddress' }, //adding the address as device attribute
 ];
 
 const PreferencesPage = () => {


### PR DESCRIPTION
This is a contribution that allows users to choose "Dynamic icons" as an icon and "Address" as a Device details (secondary text):

### **1- Dynamic icons:**

In the device now you can choose Dynamic icon and this allows you to view the stat of the device (moving, idling and parked) directly in the device list or in the map and it changes dynamically depending on the state, 

to allow this to work,we need to add a _calculated attribute_ as follows:

**Description:** Dynamic status
**Attribut:** dynamicStatus
**Expression:**
`motion ? 'moving' : (ignition ? 'idling' : 'parked')`
**Type:** String

### **2 - Address:**

Now the Address can be choose as device details (secondary text), just make sure that Traccar is connected to an _unlimited reverse geocoding server_ and the conf file is correctly configured to always display the address.

**PS** 
I also added the total number of devices in the search bar.

