### PR TITLE
fix(DeviceRow): update prop from data to devices

### DIFF
--- a/src/main/MainToolbar.jsx
+++ b/src/main/MainToolbar.jsx
@@ -101,7 +101,7 @@ const MainToolbar = ({
         disableEnforceFocus
       >
         {filteredDevices.slice(0, 3).map((_, index) => (
-          <DeviceRow key={filteredDevices[index].id} data={filteredDevices} index={index} />
+          <DeviceRow key={filteredDevices[index].id} devices={filteredDevices} index={index} />
         ))}
         {filteredDevices.length > 3 && (
           <ListItemButton alignItems="center" onClick={() => setDevicesOpen(true)}>


### PR DESCRIPTION
Changed DeviceRow prop from `data` to `devices` and updated usage.  
This fixes a runtime error on mobile view where `DeviceRow` was still receiving `data` instead of `devices`.
