### PR TITLE
Fix visibility of the close button in status card

### DIFF
--- a/src/common/components/StatusCard.jsx
+++ b/src/common/components/StatusCard.jsx
@@ -49,7 +49,8 @@ const useStyles = makeStyles()((theme, { desktopPadding }) => ({
     alignItems: 'flex-start',
   },
   mediaButton: {
-    color: theme.palette.primary.contrastText,
+    color: theme.palette.text.primary,
+    backgroundColor: theme.palette.background.default + '88',
     mixBlendMode: 'difference',
   },
   header: {


### PR DESCRIPTION
The close button is not visible when there is an image for the device and the theme of the phone is dark, but it is there and you can click on it if you know where exactly it is:
![IMG_20251027_140623](https://github.com/user-attachments/assets/cbcc215e-83a0-43c8-9d4c-d0ba12b6387e)

I've added a line with the device name and the close button like it is when there is no image.

This behavior is happening on Pixel 7 and Pixel 8 with Chrome and Firefox.