### PR TITLE
fix: Improve position readability on map

### DIFF
--- a/src/map/MapPositions.js
+++ b/src/map/MapPositions.js
@@ -114,10 +114,11 @@ const MapPositions = ({ positions, onMapClick, onMarkerClick, showStatus, select
           'text-offset': [0, -2 * iconScale],
           'text-font': findFonts(map),
           'text-size': 12,
+          'symbol-sort-key': ['get', 'id'],
         },
         paint: {
           'text-halo-color': 'white',
-          'text-halo-width': 1,
+          'text-halo-width': 2,
         },
       });
       map.addLayer({


### PR DESCRIPTION
Hi,

when the change from the old web interface map library (Leaflet?) to maplibre-gl happened, the readability of the device names on the map became worse if there are a lot of devices together. I looked into this at the time, but it was simply a limitation of maplibre-gl - but with the introduction of 'symbol-sort-key' in new-er versions, this can be mitigated - see https://github.com/mapbox/mapbox-gl-js/issues/10002#issuecomment-2475905863 

I did increase the halo width too, because I think it's a lot more readable like that.
Old:
<img width="328" height="301" alt="Screenshot From 2025-11-11 10-20-54" src="https://github.com/user-attachments/assets/7d4aaff3-69f3-4cae-938b-478e6d9c9cbf" />
New:
<img width="328" height="301" alt="Screenshot From 2025-11-11 10-20-40" src="https://github.com/user-attachments/assets/930be3ef-2fa5-442a-86bb-d21978f240d0" />
