### PR TITLE
Fix scheduled report breadcrumbs

### DIFF
--- a/src/reports/ScheduledPage.jsx
+++ b/src/reports/ScheduledPage.jsx
@@ -57,7 +57,7 @@ const ScheduledPage = () => {
   };
 
   return (
-    <PageLayout menu={<ReportsMenu />} breadcrumbs={['settingsTitle', 'reportScheduled']}>
+    <PageLayout menu={<ReportsMenu />} breadcrumbs={['reportTitle', 'reportScheduled']}>
       <Table>
         <TableHead>
           <TableRow>


### PR DESCRIPTION
```Scheduled Reports``` breadcrumbs shows ```Settings```, instead of ```Reports``` like other ```Reports``` menu items.