### PR TITLE
Show computed attributes name also in Name column on positions detail…

### DIFF
--- a/src/other/PositionPage.jsx
+++ b/src/other/PositionPage.jsx
@@ -46,14 +46,20 @@ const PositionPage = () => {
   const { id } = useParams();
 
   const [item, setItem] = useState();
+  const [computedAttributes, setComputedAttributes] = useState(new Set());
 
   useEffectAsync(async () => {
     if (id) {
-      const response = await fetchOrThrow(`/api/positions?id=${id}`);
-      const positions = await response.json();
+      const [positionsResponse, attributesResponse] = await Promise.all([
+        fetchOrThrow(`/api/positions?id=${id}`),
+        fetchOrThrow('/api/attributes/computed'),
+      ]);
+      const positions = await positionsResponse.json();
       if (positions.length > 0) {
         setItem(positions[0]);
       }
+      const attributes = await attributesResponse.json();
+      setComputedAttributes(new Set(attributes.map((a) => a.attribute)));
     }
   }, [id]);
 
@@ -108,7 +114,7 @@ const PositionPage = () => {
                     <TableRow key={attribute}>
                       <TableCell>{attribute}</TableCell>
                       <TableCell>
-                        <strong>{positionAttributes[attribute]?.name}</strong>
+                        <strong>{positionAttributes[attribute]?.name || (computedAttributes.has(attribute) ? attribute : '')}</strong>
                       </TableCell>
                       <TableCell>
                         <PositionValue position={item} attribute={attribute} />


### PR DESCRIPTION
I thought it might look a bit cleaner if the name for a computed attribute is also shown in the name column of the position details page. What do you think?

I also thought of using the description for that purpose, but that doesn't sound correct.