### PR TITLE
Added Pushover sound configuration support

### DIFF
--- a/src/common/attributes/useUserAttributes.js
+++ b/src/common/attributes/useUserAttributes.js
@@ -15,6 +15,10 @@ export default (t) =>
         name: t('attributePushoverDeviceNames'),
         type: 'string',
       },
+      pushoverNotificationSound: {
+        name: t('attributePushoverNotificationSound'),
+        type: 'string',
+      },
       'mail.smtp.host': {
         name: t('attributeMailSmtpHost'),
         type: 'string',

--- a/src/resources/l10n/en.json
+++ b/src/resources/l10n/en.json
@@ -145,6 +145,7 @@
     "attributeTelegramChatId": "Telegram Chat ID",
     "attributePushoverUserKey": "Pushover User Key",
     "attributePushoverDeviceNames": "Pushover Device Names",
+    "attributePushoverNotificationSound": "Pushover Notification Sound",
     "attributeMailSmtpHost": "Email: SMTP Host",
     "attributeMailSmtpPort": "Email: SMTP Port",
     "attributeMailSmtpStarttlsEnable": "Email: SMTP STARTTLS Enable",


### PR DESCRIPTION
**Purpose**: All Pushover notifications default to the `pushover (default)` sound.

**Solution:** This PR implements user configurable Pushover notification sounds.