### PR TITLE
Fix MenuItem icon text spacing

### DIFF
--- a/src/common/components/MenuItem.jsx
+++ b/src/common/components/MenuItem.jsx
@@ -6,13 +6,16 @@ const useStyles = makeStyles()(() => ({
   menuItemText: {
     whiteSpace: 'nowrap',
   },
+  menuItemIcon: {
+    minWidth: '55px',
+  },
 }));
 
 const MenuItem = ({ title, link, icon, selected }) => {
   const { classes } = useStyles();
   return (
     <ListItemButton key={link} component={Link} to={link} selected={selected}>
-      <ListItemIcon>{icon}</ListItemIcon>
+      <ListItemIcon className={classes.menuItemIcon}>{icon}</ListItemIcon>
       <ListItemText primary={title} className={classes.menuItemText} />
     </ListItemButton>
   );

--- a/src/common/components/MenuItem.jsx
+++ b/src/common/components/MenuItem.jsx
@@ -6,9 +6,6 @@ const useStyles = makeStyles()(() => ({
   menuItemText: {
     whiteSpace: 'nowrap',
   },
-  menuItemIcon: {
-    minWidth: '55px',
-  },
 }));
 
 const MenuItem = ({ title, link, icon, selected }) => {

--- a/src/common/components/MenuItem.jsx
+++ b/src/common/components/MenuItem.jsx
@@ -15,7 +15,7 @@ const MenuItem = ({ title, link, icon, selected }) => {
   const { classes } = useStyles();
   return (
     <ListItemButton key={link} component={Link} to={link} selected={selected}>
-      <ListItemIcon className={classes.menuItemIcon}>{icon}</ListItemIcon>
+      <ListItemIcon>{icon}</ListItemIcon>
       <ListItemText primary={title} className={classes.menuItemText} />
     </ListItemButton>
   );

--- a/src/common/components/PageLayout.jsx
+++ b/src/common/components/PageLayout.jsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()((theme, { miniVariant }) => ({
     },
   },
   desktopDrawer: {
-    width: miniVariant ? `calc(${theme.spacing(8)} + 1px)` : theme.dimensions.drawerWidthDesktop,
+    width: miniVariant ? `calc(${theme.spacing(6)} + 5px)` : theme.dimensions.drawerWidthDesktop,
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,


### PR DESCRIPTION
**Purpose:** Update to MUI 9 reduced spacing between the MenuItem icon and text, causing text to be displayed when drawer collapsed. 

**Solution:** This PR restores spacing between MenuItem icon and text similar to MUI 7.
