### PR TITLE
Prevent real-time position updates from overwriting accumulator edits

### DIFF
--- a/src/settings/AccumulatorsPage.jsx
+++ b/src/settings/AccumulatorsPage.jsx
@@ -33,14 +33,14 @@ const AccumulatorsPage = () => {
   const [item, setItem] = useState();
 
   useEffect(() => {
-    if (position) {
+    if (position && !item) {
       setItem({
         deviceId: parseInt(deviceId, 10),
         hours: position.attributes.hours || 0,
         totalDistance: position.attributes.totalDistance || 0,
       });
     }
-  }, [deviceId, position]);
+  }, [deviceId, position, item]);
 
   const handleSave = useCatch(async () => {
     await fetchOrThrow(`/api/devices/${deviceId}/accumulators`, {

--- a/src/settings/AccumulatorsPage.jsx
+++ b/src/settings/AccumulatorsPage.jsx
@@ -33,20 +33,25 @@ const AccumulatorsPage = () => {
   const [item, setItem] = useState();
 
   useEffect(() => {
-    if (position) {
+    if (position && !item) {
       setItem({
         deviceId: parseInt(deviceId, 10),
-        hours: position.attributes.hours || 0,
-        totalDistance: position.attributes.totalDistance || 0,
+        hours: (position.attributes.hours || 0) / 3_600_000,
+        totalDistance: distanceFromMeters(position.attributes.totalDistance || 0, distanceUnit),
       });
     }
-  }, [deviceId, position]);
+  }, [deviceId, position, item, distanceUnit]);
 
   const handleSave = useCatch(async () => {
+    const updateItem = {
+      ...item,
+      hours: item.hours * 3_600_000,
+      totalDistance: distanceToMeters(item.totalDistance, distanceUnit),
+    };
     await fetchOrThrow(`/api/devices/${deviceId}/accumulators`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(item),
+      body: JSON.stringify(updateItem),
     });
     navigate(-1);
   });
@@ -62,20 +67,15 @@ const AccumulatorsPage = () => {
             <AccordionDetails className={classes.details}>
               <TextField
                 type="number"
-                value={item.hours / 3600000}
-                onChange={(event) =>
-                  setItem({ ...item, hours: Number(event.target.value) * 3600000 })
-                }
+                value={item.hours}
+                onChange={(event) => setItem({ ...item, hours: Number(event.target.value) })}
                 label={t('positionHours')}
               />
               <TextField
                 type="number"
-                value={distanceFromMeters(item.totalDistance, distanceUnit)}
+                value={item.totalDistance}
                 onChange={(event) =>
-                  setItem({
-                    ...item,
-                    totalDistance: distanceToMeters(Number(event.target.value), distanceUnit),
-                  })
+                  setItem({ ...item, totalDistance: Number(event.target.value) })
                 }
                 label={`${t('deviceTotalDistance')} (${distanceUnitString(distanceUnit, t)})`}
               />

--- a/src/settings/AccumulatorsPage.jsx
+++ b/src/settings/AccumulatorsPage.jsx
@@ -33,25 +33,20 @@ const AccumulatorsPage = () => {
   const [item, setItem] = useState();
 
   useEffect(() => {
-    if (position && !item) {
+    if (position) {
       setItem({
         deviceId: parseInt(deviceId, 10),
-        hours: (position.attributes.hours || 0) / 3_600_000,
-        totalDistance: distanceFromMeters(position.attributes.totalDistance || 0, distanceUnit),
+        hours: position.attributes.hours || 0,
+        totalDistance: position.attributes.totalDistance || 0,
       });
     }
-  }, [deviceId, position, item, distanceUnit]);
+  }, [deviceId, position]);
 
   const handleSave = useCatch(async () => {
-    const updateItem = {
-      ...item,
-      hours: item.hours * 3_600_000,
-      totalDistance: distanceToMeters(item.totalDistance, distanceUnit),
-    };
     await fetchOrThrow(`/api/devices/${deviceId}/accumulators`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updateItem),
+      body: JSON.stringify(item),
     });
     navigate(-1);
   });
@@ -67,15 +62,20 @@ const AccumulatorsPage = () => {
             <AccordionDetails className={classes.details}>
               <TextField
                 type="number"
-                value={item.hours}
-                onChange={(event) => setItem({ ...item, hours: Number(event.target.value) })}
+                value={item.hours / 3600000}
+                onChange={(event) =>
+                  setItem({ ...item, hours: Number(event.target.value) * 3600000 })
+                }
                 label={t('positionHours')}
               />
               <TextField
                 type="number"
-                value={item.totalDistance}
+                value={distanceFromMeters(item.totalDistance, distanceUnit)}
                 onChange={(event) =>
-                  setItem({ ...item, totalDistance: Number(event.target.value) })
+                  setItem({
+                    ...item,
+                    totalDistance: distanceToMeters(Number(event.target.value), distanceUnit),
+                  })
                 }
                 label={`${t('deviceTotalDistance')} (${distanceUnitString(distanceUnit, t)})`}
               />


### PR DESCRIPTION
Previously, editing the hours or total distance accumulators had two main issues:
1. Incoming real-time position updates would overwrite the user's input mid-edit.
2. Typing a specific distance (e.g., 42 miles) would immediately change to a floating-point approximation (e.g., 42.00000000000001) due to continuous two-way unit conversion between the input field and the underlying state.

This commit fixes only issue 1 (after discussing things) by:
- No longer updating inputs when device position is updated