### PR TITLE
Add PMTiles protocol support for custom maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "hls.js": "^1.6.16",
         "maplibre-gl": "^5.24.0",
         "maplibre-google-maps": "^1.1.0",
+        "pmtiles": "^4.4.1",
         "react": "^19.2.6",
         "react-country-flag": "3.1.0",
         "react-dom": "^19.2.6",
@@ -7505,6 +7506,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -9798,6 +9805,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pmtiles": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.4.1.tgz",
+      "integrity": "sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fflate": "^0.8.2"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "hls.js": "^1.6.16",
     "maplibre-gl": "^5.24.0",
     "maplibre-google-maps": "^1.1.0",
+    "pmtiles": "^4.4.1",
     "react": "^19.2.6",
     "react-country-flag": "3.1.0",
     "react-dom": "^19.2.6",

--- a/src/map/core/MapView.jsx
+++ b/src/map/core/MapView.jsx
@@ -18,8 +18,7 @@ element.style.boxSizing = 'initial';
 
 maplibregl.addProtocol('google', googleProtocol);
 
-const pmtilesProtocol = new PMTilesProtocol();
-maplibregl.addProtocol('pmtiles', pmtilesProtocol.tile);
+maplibregl.addProtocol('pmtiles', new PMTilesProtocol().tile);
 
 export const map = new maplibregl.Map({
   container: element,

--- a/src/map/core/MapView.jsx
+++ b/src/map/core/MapView.jsx
@@ -1,6 +1,7 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import maplibregl from 'maplibre-gl';
 import { googleProtocol } from 'maplibre-google-maps';
+import { Protocol as PMTilesProtocol } from 'pmtiles';
 import { useRef, useLayoutEffect, useEffect, useState, useMemo } from 'react';
 import { useTheme } from '@mui/material';
 import MapSwitcher from '../control/MapSwitcher';
@@ -16,6 +17,9 @@ element.style.height = '100%';
 element.style.boxSizing = 'initial';
 
 maplibregl.addProtocol('google', googleProtocol);
+
+const pmtilesProtocol = new PMTilesProtocol();
+maplibregl.addProtocol('pmtiles', pmtilesProtocol.tile);
 
 export const map = new maplibregl.Map({
   container: element,


### PR DESCRIPTION
## Summary

Registers the `pmtiles://` protocol with MapLibre so a custom map URL can point to a style.json whose vector sources are backed by a [PMTiles](https://docs.protomaps.com/pmtiles/) archive.

This makes it possible to use serverless, single-file vector basemaps hosted on commodity storage (S3, R2, etc.) without running a tile server.

This is also useful for offline or self-hosted deployments where users want to keep a single-file vector basemap next to Traccar, without running a separate tile server.

The existing custom map handling already passes a non-template style URL straight to `map.setStyle`, so registering the protocol is all that is needed.

## Impact

This change is purely additive and introduces no breaking changes. Every existing map keeps working exactly as before, whether it is a raster tile source, a vector style URL, or one of the provider maps (Google, Mapbox, MapTiler, and so on). The only new behavior is that a style referencing `pmtiles://` URLs now resolves instead of failing with an unknown protocol error, so this simply unlocks PMTiles support for anyone who wants it without affecting anyone who does not.

## Changes

- Add the `pmtiles` dependency.
- Register the `pmtiles` protocol next to the existing `google` protocol in `MapView.jsx`.

## Testing

Verified against a local traccar server by setting the custom map URL to a style.json whose sources use `pmtiles://.../planet.pmtiles` (OpenMapTiles schema). The map renders correctly and fetches tiles via HTTP Range requests (206 Partial Content) with no errors. Also confirmed with the Protomaps basemap schema.
