### PR TITLE
[FEAT]: Change expiration input type to datetime-local

### DIFF
--- a/src/settings/SharePage.jsx
+++ b/src/settings/SharePage.jsx
@@ -31,7 +31,7 @@ const SharePage = () => {
   );
 
   const [expiration, setExpiration] = useState(() =>
-    dayjs().add(1, 'week').locale('en').format('YYYY-MM-DD'),
+    dayjs().add(1, 'week').locale('en').format('YYYY-MM-DDTHH:mm'),
   );
   const [link, setLink] = useState();
 
@@ -60,7 +60,7 @@ const SharePage = () => {
             />
             <TextField
               label={t('userExpirationTime')}
-              type="date"
+              type="datetime-local"
               value={expiration}
               onChange={(e) => setExpiration(e.target.value)}
             />


### PR DESCRIPTION
The share API already supports an exact expiration timestamp, but the share page only exposes a date input. This change switches the input to datetime-local so short-lived share links can be created from the UI as well.

No API or schema changes are required.