### PR TITLE
Add geofence filter to main screen device list

### DIFF
--- a/src/main/MainPage.jsx
+++ b/src/main/MainPage.jsx
@@ -86,6 +86,7 @@ const MainPage = () => {
   const [filter, setFilter] = usePersistedState('filter', {
     statuses: [],
     groups: [],
+    geofences: [],
   });
   const [filterSort, setFilterSort] = usePersistedState('filterSort', '');
   const [filterMap, setFilterMap] = usePersistedState('filterMap', false);

--- a/src/main/MainToolbar.jsx
+++ b/src/main/MainToolbar.jsx
@@ -65,6 +65,7 @@ const MainToolbar = ({
 
   const groups = useSelector((state) => state.groups.items);
   const devices = useSelector((state) => state.devices.items);
+  const geofences = useSelector((state) => state.geofences.items);
 
   const toolbarRef = useRef();
   const inputRef = useRef();
@@ -92,7 +93,9 @@ const MainToolbar = ({
               <Badge
                 color="info"
                 variant="dot"
-                invisible={!filter.statuses.length && !filter.groups.length}
+                invisible={
+                  !filter.statuses.length && !filter.groups.length && !filter.geofences.length
+                }
               >
                 <TuneIcon fontSize="small" />
               </Badge>
@@ -165,6 +168,23 @@ const MainToolbar = ({
                 .map((group) => (
                   <MenuItem key={group.id} value={group.id}>
                     {group.name}
+                  </MenuItem>
+                ))}
+            </Select>
+          </FormControl>
+          <FormControl>
+            <InputLabel>{t('sharedGeofences')}</InputLabel>
+            <Select
+              label={t('sharedGeofences')}
+              value={filter.geofences}
+              onChange={(e) => setFilter({ ...filter, geofences: e.target.value })}
+              multiple
+            >
+              {Object.values(geofences)
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((geofence) => (
+                  <MenuItem key={geofence.id} value={geofence.id}>
+                    {geofence.name}
                   </MenuItem>
                 ))}
             </Select>

--- a/src/main/useFilter.js
+++ b/src/main/useFilter.js
@@ -31,6 +31,11 @@ export default (
         (device) =>
           !filter.groups.length || deviceGroups(device).some((id) => filter.groups.includes(id)),
       )
+      .filter(
+        (device) =>
+          !filter.geofences.length ||
+          (positions[device.id]?.geofenceIds || []).some((id) => filter.geofences.includes(id)),
+      )
       .filter((device) => {
         const lowerCaseKeyword = keyword.toLowerCase();
         return [device.name, device.uniqueId, device.phone, device.model, device.contact].some(


### PR DESCRIPTION
Adds a Geofence filter to the main screen filter panel (closes traccar/traccar#5815).

Devices are filtered by the `geofenceIds` of their latest position, consistent with the existing Status and Group filters. Selecting multiple geofences shows any device currently inside at least one of them

Note: relies on the server-computed `position.geofenceIds`. A geofence must be assigned to the device, and the device must report a position after assignment for it to match