### PR TITLE
Initial commit: Added calendar to playback page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3273,9 +3273,12 @@
         "arm64"
       ],
       "dev": true,
+<<<<<<< HEAD
       "libc": [
         "glibc"
       ],
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3293,9 +3296,12 @@
         "arm64"
       ],
       "dev": true,
+<<<<<<< HEAD
       "libc": [
         "musl"
       ],
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3313,9 +3319,12 @@
         "ppc64"
       ],
       "dev": true,
+<<<<<<< HEAD
       "libc": [
         "glibc"
       ],
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3333,9 +3342,12 @@
         "s390x"
       ],
       "dev": true,
+<<<<<<< HEAD
       "libc": [
         "glibc"
       ],
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3353,9 +3365,12 @@
         "x64"
       ],
       "dev": true,
+<<<<<<< HEAD
       "libc": [
         "glibc"
       ],
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3373,9 +3388,12 @@
         "x64"
       ],
       "dev": true,
+<<<<<<< HEAD
       "libc": [
         "musl"
       ],
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/common/util/cacheUtils.js
+++ b/src/common/util/cacheUtils.js
@@ -1,0 +1,31 @@
+const CACHE_PREFIX = 'traccar_cache_';
+const DEFAULT_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
+
+export const getCacheItem = (key) => {
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    if (!raw) return null;
+    const item = JSON.parse(raw);
+    if (Date.now() - item.timestamp > DEFAULT_TTL) {
+      localStorage.removeItem(CACHE_PREFIX + key);
+      return null;
+    }
+    return item;
+  } catch {
+    return null;
+  }
+};
+
+export const setCacheItem = (key, data) => {
+  try {
+    localStorage.setItem(
+      CACHE_PREFIX + key,
+      JSON.stringify({
+        timestamp: Date.now(),
+        data,
+      }),
+    );
+  } catch (e) {
+    console.warn('Cache write failed:', e);
+  }
+};

--- a/src/other/ReplayCalendar.jsx
+++ b/src/other/ReplayCalendar.jsx
@@ -1,0 +1,337 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  IconButton,
+  Typography,
+  CircularProgress,
+} from '@mui/material';
+import { makeStyles } from 'tss-react/mui';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import dayjs from 'dayjs';
+import { useTranslation } from '../common/components/LocalizationProvider';
+import { distanceFromMeters, distanceUnitString } from '../common/util/converter';
+import { useAttributePreference } from '../common/util/preferences';
+import fetchOrThrow from '../common/util/fetchOrThrow';
+import { getCacheItem, setCacheItem } from '../common/util/cacheUtils';
+
+const CELL_SIZE = 56;
+
+const useStyles = makeStyles()((theme) => ({
+  calendarPanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: theme.spacing(1),
+    userSelect: 'none',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: theme.spacing(0, 1),
+  },
+  monthTitle: {
+    fontWeight: 600,
+    fontSize: '1rem',
+  },
+  weekdayRow: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(7, 1fr)',
+    textAlign: 'center',
+    marginTop: theme.spacing(1),
+  },
+  weekdayLabel: {
+    fontSize: '0.75rem',
+    color: theme.palette.text.secondary,
+    padding: theme.spacing(0.5, 0),
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(7, 1fr)',
+    gap: 1,
+  },
+  dayCell: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: CELL_SIZE,
+    minWidth: 0,
+    borderRadius: theme.shape.borderRadius,
+    cursor: 'pointer',
+    padding: theme.spacing(0.25, 0),
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+  today: {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    fontWeight: 700,
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+    },
+  },
+  todayDimmed: {
+    fontWeight: 600,
+    textDecoration: 'underline',
+    textDecorationColor: theme.palette.primary.main,
+    textUnderlineOffset: 2,
+    opacity: 0.55,
+  },
+  selected: {
+    outline: `2px solid ${theme.palette.primary.main}`,
+    outlineOffset: -2,
+    borderRadius: '50%',
+    fontWeight: 700,
+  },
+  dayNumber: {
+    fontSize: '0.85rem',
+    lineHeight: 1.2,
+  },
+  dayDistance: {
+    fontSize: '0.6rem',
+    lineHeight: 1.1,
+    color: theme.palette.text.secondary,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: '100%',
+    padding: '0 2px',
+  },
+  todayDistance: {
+    color: 'inherit',
+    opacity: 0.85,
+  },
+  futureDay: {
+    opacity: 0.35,
+    cursor: 'default',
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
+  },
+  emptyCell: {
+    height: CELL_SIZE,
+  },
+  loadingOverlay: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: theme.spacing(2),
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: theme.spacing(1, 0, 0, 0),
+  },
+}));
+
+const cacheKey = (deviceId, year, month) => `summary_${deviceId}_${year}-${String(month).padStart(2, '0')}`;
+
+const ReplayCalendar = ({ selectedDeviceId, selectedDate, onDaySelect }) => {
+  const t = useTranslation();
+  const { classes, cx } = useStyles();
+  const distanceUnit = useAttributePreference('distanceUnit');
+
+  const today = useMemo(() => dayjs(), []);
+  const [viewDate, setViewDate] = useState(today);
+  const [dailyData, setDailyData] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  const year = viewDate.year();
+  const month = viewDate.month(); // 0-based
+
+  // Helper: get the last day to fetch (today for current month, end of month for past months)
+  const getFetchRange = useCallback(() => {
+    const startOfMonth = viewDate.startOf('month');
+    const endOfFetch = viewDate.isSame(today, 'month')
+      ? today.endOf('day')
+      : viewDate.endOf('month').endOf('day');
+    return { from: startOfMonth, to: endOfFetch };
+  }, [viewDate, today]);
+
+  // Fetch monthly summary data
+  useEffect(() => {
+    if (!selectedDeviceId) return;
+
+    const key = cacheKey(selectedDeviceId, year, month + 1);
+    const cached = getCacheItem(key);
+
+    if (cached) {
+      // Check if cache was fetched before today but we're in the current month
+      // (meaning today's data might be missing)
+      const cachedDate = dayjs(cached.timestamp);
+      if (
+        viewDate.isSame(today, 'month') &&
+        !cachedDate.isSame(today, 'day') &&
+        cachedDate.isBefore(today, 'day')
+      ) {
+        // Cache is stale for current month - refetch
+        fetchMonthlyData();
+      } else {
+        setDailyData(buildDailyMap(cached.data));
+        return;
+      }
+    } else {
+      fetchMonthlyData();
+    }
+
+    async function fetchMonthlyData() {
+      const { from, to } = getFetchRange();
+      setLoading(true);
+      try {
+        const query = new URLSearchParams({
+          deviceId: selectedDeviceId,
+          from: from.toISOString(),
+          to: to.toISOString(),
+          daily: true,
+        });
+        const response = await fetchOrThrow(`/api/reports/summary?${query.toString()}`, {
+          headers: { Accept: 'application/json' },
+        });
+        const data = await response.json();
+        setCacheItem(key, data);
+        setDailyData(buildDailyMap(data));
+      } catch (e) {
+        // If no data, just show empty calendar
+        setDailyData({});
+      } finally {
+        setLoading(false);
+      }
+    }
+  }, [selectedDeviceId, year, month, viewDate, today, getFetchRange]);
+
+  const buildDailyMap = (data) => {
+    const map = {};
+    data.forEach((item) => {
+      const dateKey = dayjs(item.startTime).format('YYYY-MM-DD');
+      // If multiple entries for same day (e.g. multiple devices), keep this device's
+      if (!map[dateKey] || item.deviceId === selectedDeviceId) {
+        map[dateKey] = item.distance;
+      }
+    });
+    return map;
+  };
+
+  const firstDayOfMonth = viewDate.startOf('month');
+  const daysInMonth = viewDate.daysInMonth();
+  const startDayOfWeek = firstDayOfMonth.day(); // 0=Sunday
+  const todayFormatted = today.format('YYYY-MM-DD');
+
+  const handlePrevMonth = () => {
+    setViewDate((prev) => prev.subtract(1, 'month'));
+  };
+
+  const handleNextMonth = () => {
+    const next = viewDate.add(1, 'month');
+    if (next.isAfter(today, 'month')) return;
+    setViewDate((prev) => {
+      const n = prev.add(1, 'month');
+      if (n.isAfter(today, 'month')) return prev;
+      return n;
+    });
+  };
+
+  const handleDayClick = (day) => {
+    const clickedDate = viewDate.date(day);
+    if (clickedDate.isAfter(today, 'day')) return;
+    const dayStart = clickedDate.startOf('day').toISOString();
+    const dayEnd = clickedDate.endOf('day').toISOString();
+    onDaySelect(selectedDeviceId, dayStart, dayEnd);
+  };
+
+  const formatDist = (meters) => {
+    if (meters === undefined || meters === null) return '';
+    const value = Math.round(distanceFromMeters(meters, distanceUnit));
+    return `${value} ${distanceUnitString(distanceUnit, t)}`;
+  };
+
+  const weekdays = Array.from({ length: 7 }, (_, i) => dayjs().day(i).format('dd'));
+
+  const cells = [];
+
+  // Empty cells before the first day
+  for (let i = 0; i < startDayOfWeek; i++) {
+    cells.push(<div key={`empty-${i}`} className={classes.emptyCell} />);
+  }
+
+  // Day cells (skip future dates)
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dateObj = viewDate.date(day);
+    if (dateObj.isAfter(today, 'day')) break;
+    const dateFormatted = dateObj.format('YYYY-MM-DD');
+    const isToday = dateFormatted === todayFormatted;
+    const isSelected = selectedDate && dateFormatted === dayjs(selectedDate).format('YYYY-MM-DD');
+    const distance = dailyData[dateFormatted];
+    const hasDistance = distance !== undefined && distance !== null;
+
+    const hasSelected = !!selectedDate;
+    const cellClasses = cx(classes.dayCell, {
+      [classes.today]: isToday && (!hasSelected || isSelected),
+      [classes.todayDimmed]: isToday && hasSelected && !isSelected,
+      [classes.selected]: isSelected && !isToday,
+    });
+
+    cells.push(
+      <div
+        key={`day-${day}`}
+        className={cellClasses}
+        onClick={() => handleDayClick(day)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleDayClick(day);
+        }}
+      >
+        <span className={classes.dayNumber}>{day}</span>
+        {hasDistance && (
+          <span className={cx(classes.dayDistance, { [classes.todayDistance]: isToday && !isSelected })}>
+            {formatDist(distance)}
+          </span>
+        )}
+      </div>,
+    );
+  }
+
+  return (
+    <div className={classes.calendarPanel}>
+      <div className={classes.header}>
+        <IconButton size="small" onClick={handlePrevMonth}>
+          <ChevronLeftIcon />
+        </IconButton>
+        <Typography className={classes.monthTitle}>
+          {viewDate.format('YYYY MMMM')}
+        </Typography>
+        <IconButton
+          size="small"
+          onClick={handleNextMonth}
+          disabled={viewDate.isSame(today, 'month')}
+        >
+          <ChevronRightIcon />
+        </IconButton>
+      </div>
+      <div className={classes.weekdayRow}>
+        {weekdays.map((wd) => (
+          <Typography key={wd} className={classes.weekdayLabel}>
+            {wd}
+          </Typography>
+        ))}
+      </div>
+      <div className={classes.grid}>
+        {cells}
+      </div>
+      {loading && (
+        <div className={classes.loadingOverlay}>
+          <CircularProgress size={20} />
+        </div>
+      )}
+      {!loading && Object.keys(dailyData).length === 0 && (
+        <div className={classes.footer}>
+          <Typography variant="caption" color="textSecondary">
+            {t('sharedNoData')}
+          </Typography>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReplayCalendar;

--- a/src/other/ReplayPage.jsx
+++ b/src/other/ReplayPage.jsx
@@ -1,7 +1,14 @@
+<<<<<<< HEAD
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { IconButton, Paper, Slider, Toolbar, Typography } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 import TuneIcon from '@mui/icons-material/Tune';
+=======
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import dayjs from 'dayjs';
+import { IconButton, Paper, Slider, Toolbar, Typography } from '@mui/material';
+import { makeStyles } from 'tss-react/mui';
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
 import DownloadIcon from '@mui/icons-material/Download';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PauseIcon from '@mui/icons-material/Pause';
@@ -14,9 +21,13 @@ import MapRoutePath from '../map/MapRoutePath';
 import MapRoutePoints from '../map/MapRoutePoints';
 import MapPositions from '../map/MapPositions';
 import { formatTime } from '../common/util/formatter';
+<<<<<<< HEAD
 import ReportFilter from '../reports/components/ReportFilter';
 import { useTranslation } from '../common/components/LocalizationProvider';
 import { useCatchCallback } from '../reactHelper';
+=======
+import { useTranslation } from '../common/components/LocalizationProvider';
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
 import MapCamera from '../map/MapCamera';
 import MapGeofence from '../map/MapGeofence';
 import StatusCard from '../common/components/StatusCard';
@@ -24,6 +35,11 @@ import MapScale from '../map/MapScale';
 import BackIcon from '../common/components/BackIcon';
 import fetchOrThrow from '../common/util/fetchOrThrow';
 import MapOverlay from '../map/overlay/MapOverlay';
+<<<<<<< HEAD
+=======
+import SelectField from '../common/components/SelectField';
+import ReplayCalendar from './ReplayCalendar';
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
 
 const useStyles = makeStyles()((theme) => ({
   root: {
@@ -80,9 +96,25 @@ const ReplayPage = () => {
   const navigate = useNavigate();
   const timerRef = useRef();
 
+<<<<<<< HEAD
   const [searchParams] = useSearchParams();
 
   const defaultDeviceId = useSelector((state) => state.devices.selectedId);
+=======
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const defaultDeviceId = useSelector((state) => {
+    const urlDeviceId = searchParams.get('deviceId');
+    if (urlDeviceId) return Number(urlDeviceId);
+    return state.devices.selectedId;
+  });
+
+  const devices = useSelector((state) => state.devices.items);
+  const deviceList = useMemo(
+    () => Object.values(devices).sort((a, b) => a.name.localeCompare(b.name)),
+    [devices],
+  );
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
 
   const [positions, setPositions] = useState([]);
   const [index, setIndex] = useState(0);
@@ -92,6 +124,7 @@ const ReplayPage = () => {
   const to = searchParams.get('to');
   const [playing, setPlaying] = useState(false);
   const [loading, setLoading] = useState(false);
+<<<<<<< HEAD
   const [filterOpen, setFilterOpen] = useState(false);
 
   const loaded = Boolean(from && to && !loading && positions.length);
@@ -106,6 +139,11 @@ const ReplayPage = () => {
     return null;
   });
 
+=======
+
+  const loaded = Boolean(from && to && !loading && positions.length);
+
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
   useEffect(() => {
     if (!from && !to) {
       setPositions([]);
@@ -131,6 +169,66 @@ const ReplayPage = () => {
     }
   }, [index, positions]);
 
+<<<<<<< HEAD
+=======
+  // Auto-load positions on mount
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const deviceIdParam = params.get('deviceId');
+    const fromParam = params.get('from');
+    const toParam = params.get('to');
+    if (deviceIdParam) {
+      if (fromParam && toParam) {
+        loadPositions(Number(deviceIdParam), fromParam, toParam, true);
+      } else {
+        // No from/to → default to today
+        const today = dayjs();
+        const todayFrom = today.startOf('day').toISOString();
+        const todayTo = today.endOf('day').toISOString();
+        const newParams = new URLSearchParams(params);
+        newParams.set('from', todayFrom);
+        newParams.set('to', todayTo);
+        setSearchParams(newParams, { replace: true });
+        loadPositions(Number(deviceIdParam), todayFrom, todayTo, true);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadPositions = async (deviceId, from, to, autoPlay) => {
+    setLoading(true);
+    setSelectedDeviceId(deviceId);
+    const query = new URLSearchParams({ deviceId, from, to });
+    try {
+      const response = await fetchOrThrow(`/api/positions?${query.toString()}`);
+      setIndex(0);
+      const data = await response.json();
+      setPositions(data);
+      if (!data.length) {
+        throw Error(t('sharedNoData'));
+      }
+      if (autoPlay && data.length) {
+        setPlaying(true);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onDaySelect = useCallback(
+    (deviceId, from, to) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('deviceId', deviceId);
+      newParams.set('from', from);
+      newParams.set('to', to);
+      setSearchParams(newParams, { replace: true });
+      loadPositions(deviceId, from, to, false);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [searchParams, setSearchParams],
+  );
+
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
   const onPointClick = useCallback(
     (_, index) => {
       setIndex(index);
@@ -145,6 +243,7 @@ const ReplayPage = () => {
     [setShowCard],
   );
 
+<<<<<<< HEAD
   const onShow = useCatchCallback(
     async ({ deviceIds, from, to }) => {
       const deviceId = deviceIds.find(() => true);
@@ -167,6 +266,8 @@ const ReplayPage = () => {
     [t],
   );
 
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
   const handleDownload = () => {
     const query = new URLSearchParams({ deviceId: selectedDeviceId, from, to });
     window.location.assign(`/api/positions/kml?${query.toString()}`);
@@ -199,6 +300,7 @@ const ReplayPage = () => {
               {t('reportReplay')}
             </Typography>
             {loaded && (
+<<<<<<< HEAD
               <>
                 <IconButton onClick={handleDownload}>
                   <DownloadIcon />
@@ -207,15 +309,45 @@ const ReplayPage = () => {
                   <TuneIcon />
                 </IconButton>
               </>
+=======
+              <IconButton onClick={handleDownload}>
+                <DownloadIcon />
+              </IconButton>
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
             )}
           </Toolbar>
         </Paper>
         <Paper className={classes.content} square>
+<<<<<<< HEAD
           {loaded && !filterOpen && (
             <>
               <Typography variant="subtitle1" align="center">
                 {deviceName}
               </Typography>
+=======
+          <div style={{ padding: '8px 12px 0' }}>
+            <SelectField
+              label={t('reportDevice')}
+              data={deviceList}
+              value={selectedDeviceId}
+              onChange={(e) => setSelectedDeviceId(e.target.value)}
+              fullWidth
+            />
+          </div>
+          {selectedDeviceId ? (
+            <ReplayCalendar
+              selectedDeviceId={selectedDeviceId}
+              selectedDate={from}
+              onDaySelect={onDaySelect}
+            />
+          ) : (
+            <Typography variant="body2" align="center" style={{ padding: 16, color: '#888' }}>
+              {t('reportDevice')}
+            </Typography>
+          )}
+          {loaded && (
+            <>
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
               <Slider
                 className={classes.slider}
                 max={positions.length - 1}
@@ -250,9 +382,12 @@ const ReplayPage = () => {
               </div>
             </>
           )}
+<<<<<<< HEAD
           <div style={{ display: loaded && !filterOpen ? 'none' : 'block' }}>
             <ReportFilter onShow={onShow} deviceType="single" loading={loading} />
           </div>
+=======
+>>>>>>> e8f8d976 (Initial commit: Added calendar to playback page)
         </Paper>
       </div>
       {showCard && index < positions.length && (


### PR DESCRIPTION
I have added a calendar date picker to the playback page, allowing users to easily select a specific date for playback instead of manually modifying the URL parameters. This should improve the user experience for historical data review.

Changes:
- Created ReplayCalendar component.
- Updated ReplayPage to include date selection logic.
<img width="1920" height="1080" alt="Screenshot" src="https://github.com/user-attachments/assets/35babce3-cac6-4c0e-ac99-9b0573cfc357" />
------
PR Description
Add Calendar Management and Data Caching
This PR introduces two major features: calendar management (backend integration + UI) and local caching for improved performance.

1. Calendar Redux Store ([calendars.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Created a new Redux slice for calendar data management:

Stores calendars keyed by ID in [state.calendars.items](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Provides a [refresh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) action to populate the store from API responses
Exported as [calendarsActions](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [calendarsReducer](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Calendar Preloading ([CachingController.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Added automatic calendar data preloading when the user is authenticated:

Fetches [/api/calendars](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on app startup
Dispatches to the Redux store so calendar data is available across all pages without redundant API calls
3. Calendar Registration in Store ([index.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Registered the [calendars](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) reducer in the root store and exported [calendarsActions](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

4. Local Storage Cache Utility ([cacheUtils.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
A lightweight caching layer backed by [localStorage](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):

[getCacheItem(key)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — retrieves cached data with a 30-day TTL; automatically removes expired entries
[setCacheItem(key, data)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — stores data with a timestamp
Used to reduce redundant network requests and improve offline resilience
5. Replay Calendar Component ([ReplayCalendar.jsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
A new interactive calendar for the playback page that shows daily trip summary distances:

Displays a full month grid with day cells
Each cell shows the total distance traveled on that day (fetched from /api/reports/summary?daily=true)
Navigate between months with prev/next arrows
Highlights today and the currently selected date
Future days are visually dimmed and non-interactive
Caches monthly summary data in [localStorage](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) via cacheUtils
Handles cache staleness for the current month (auto-refetches if today's data may be missing)
6. Replay Page Enhancements ([ReplayPage.jsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Enhanced the playback page with:

Integrated the new [ReplayCalendar](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) component for date selection
Added a device selector dropdown (populated from Redux store)
Auto-loads positions on mount based on URL query parameters
When no [from](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[to](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) parameters are provided, defaults to today's date range
Removed the old [ReportFilter](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) usage