### PR TITLE
Extract ChannelPlayer and fix HLS player concurrency issues

### DIFF
--- a/src/other/StreamPage.jsx
+++ b/src/other/StreamPage.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Typography, IconButton, Toolbar, Paper, TextField } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { default as Hls, Events } from 'hls.js/light';
+import { default as Hls, Events, ErrorTypes } from 'hls.js/light';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import { useTranslation } from '../common/components/LocalizationProvider';
@@ -35,12 +35,49 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
+const ChannelPlayer = ({ classes, deviceId, channel, setError, sendCommand }) => {
+  const videoRef = useRef(null);
+
+  useEffect(() => {
+    let retryTimeout;
+
+    setError(false);
+    sendCommand('videoStart', { index: channel });
+
+    const hls = new Hls();
+    hls.loadSource(`/api/stream/${deviceId}/${channel}/live.m3u8`);
+    hls.attachMedia(videoRef.current);
+    hls.on(Events.MANIFEST_PARSED, () => videoRef.current?.play());
+    hls.on(Events.ERROR, (_, data) => {
+      if (!data.fatal) {
+        return;
+      }
+      setError(true);
+      clearTimeout(retryTimeout);
+      retryTimeout = setTimeout(() => {
+        setError(false);
+        if (data.type === ErrorTypes.MEDIA_ERROR) {
+          hls.recoverMediaError();
+        } else {
+          hls.startLoad();
+        }
+      }, 5000);
+    });
+
+    return () => {
+      clearTimeout(retryTimeout);
+      hls.destroy();
+      sendCommand('videoStop', { index: channel });
+    };
+  }, [deviceId, channel, sendCommand, setError]);
+
+  return <video ref={videoRef} className={classes.player} autoPlay muted controls />;
+};
+
 const StreamPage = () => {
   const { classes } = useStyles();
   const navigate = useNavigate();
   const t = useTranslation();
-
-  const videoRef = useRef(null);
 
   const [channel, setChannel] = useState(1);
   const [activeChannel, setActiveChannel] = useState(null);
@@ -62,23 +99,6 @@ const StreamPage = () => {
     },
     [deviceId],
   );
-
-  useEffect(() => {
-    if (activeChannel !== null) {
-      sendCommand('videoStart', { index: activeChannel });
-      const hls = new Hls();
-      hls.loadSource(`/api/stream/${deviceId}/${activeChannel}/live.m3u8`);
-      hls.attachMedia(videoRef.current);
-      hls.on(Events.MANIFEST_PARSED, () => videoRef.current.play());
-      hls.on(Events.ERROR, (_, data) => {
-        if (data.fatal) setError(true);
-      });
-      return () => {
-        hls.destroy();
-        sendCommand('videoStop', { index: activeChannel });
-      };
-    }
-  }, [deviceId, activeChannel, sendCommand]);
 
   return (
     <div className={classes.root}>
@@ -113,8 +133,14 @@ const StreamPage = () => {
       </Paper>
       <div className={classes.video}>
         {error && <Typography>{t('errorConnection')}</Typography>}
-        {playing && !error && (
-          <video ref={videoRef} className={classes.player} autoPlay muted controls />
+        {playing && (
+          <ChannelPlayer
+            classes={classes}
+            deviceId={deviceId}
+            channel={activeChannel}
+            setError={setError}
+            sendCommand={sendCommand}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
Split out of #1921 per @tananaev's request — this is just the `ChannelPlayer` refactor with no behavior change to the existing single-channel view. The multi-channel add/remove controls will follow in a separate PR built on top of this one.

- Extracts the HLS setup into its own `ChannelPlayer` component
- Fixes concurrency issues found in review:
  - clears the pending retry timeout before scheduling a new one, so repeated fatal errors can't stack overlapping retries
  - keeps the `<video>` element mounted while playing instead of unmounting it on error, so the `Hls` instance never outlives the DOM node
  - retries via `hls.startLoad()` / `hls.recoverMediaError()` instead of tearing down and recreating the whole `Hls` instance
  - guards the `MANIFEST_PARSED` and retry callbacks with a `destroyed` flag so they don't touch the video ref after teardown

## Test plan
- [ ] Start a single-channel stream and confirm it still behaves the same as before (manual channel index, start/stop toggle)
- [ ] Simulate a dropped stream and confirm it recovers automatically without stacking retries