### PR TITLE
Add storage failure alarm translations

### DIFF
--- a/src/resources/l10n/en.json
+++ b/src/resources/l10n/en.json
@@ -542,6 +542,7 @@
     "alarmLowPower": "Low Power",
     "alarmLowBattery": "Low Battery",
     "alarmFault": "Fault",
+    "alarmStorageFailure": "Storage Failure",
     "alarmPowerOff": "Power Off",
     "alarmPowerOn": "Power On",
     "alarmDoor": "Door",

--- a/src/resources/l10n/es.json
+++ b/src/resources/l10n/es.json
@@ -542,6 +542,7 @@
     "alarmLowPower": "Energía baja",
     "alarmLowBattery": "Batería Baja",
     "alarmFault": "Alarma de fallo",
+    "alarmStorageFailure": "Fallo de almacenamiento",
     "alarmPowerOff": "Apagado",
     "alarmPowerOn": "Encendido",
     "alarmDoor": "Puerta",


### PR DESCRIPTION
## Purpose

This is the Traccar Web companion to traccar/traccar#5968.

The backend pull request introduces the `storageFailure` alarm value when a JT808/JT1078 device reports a storage unit failure. Without a matching localization key, the UI cannot present a clear alarm description.

## Change

Add `alarmStorageFailure` translations:

- English: `Storage Failure`
- Spanish: `Fallo de almacenamiento`

<img width="1798" height="921" alt="image" src="https://github.com/user-attachments/assets/2e1e4699-e417-4f70-9a8c-626b1b76c9c7" />

## Dependency

- Backend protocol and alarm change: https://github.com/traccar/traccar/pull/5968

This pull request only adds presentation strings. The alarm value and JT808 decoding are implemented in the linked backend pull request.

## Validation

- `npm ci`
- `npm run lint`
- `npm run build`
- `git diff --check`