### PR TITLE
Add setSpeedLimit command attributes

### DIFF
--- a/src/common/attributes/useCommandAttributes.js
+++ b/src/common/attributes/useCommandAttributes.js
@@ -148,6 +148,11 @@ export default (t) =>
           name: t('attributeSpeedLimit'),
           type: 'number',
         },
+        {
+          key: 'duration',
+          name: t('reportDuration'),
+          type: 'number',
+        },
       ],
       modePowerSaving: [
         {

--- a/src/common/attributes/useCommandAttributes.js
+++ b/src/common/attributes/useCommandAttributes.js
@@ -148,12 +148,6 @@ export default (t) =>
           name: t('attributeSpeedLimit'),
           type: 'number',
         },
-        {
-          key: 'duration',
-          name: t('reportDuration'),
-          type: 'number',
-          protocol: 'jt808',
-        },
       ],
       modePowerSaving: [
         {

--- a/src/common/attributes/useCommandAttributes.js
+++ b/src/common/attributes/useCommandAttributes.js
@@ -142,6 +142,19 @@ export default (t) =>
           type: 'string',
         },
       ],
+      setSpeedLimit: [
+        {
+          key: 'data',
+          name: t('attributeSpeedLimit'),
+          type: 'number',
+        },
+        {
+          key: 'duration',
+          name: t('reportDuration'),
+          type: 'number',
+          protocol: 'jt808',
+        },
+      ],
       modePowerSaving: [
         {
           key: 'enable',

--- a/src/settings/components/BaseCommandView.jsx
+++ b/src/settings/components/BaseCommandView.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Autocomplete, Checkbox, FormControlLabel, TextField } from '@mui/material';
 import { useTranslation } from '../../common/components/LocalizationProvider';
@@ -20,6 +20,8 @@ const BaseCommandView = ({
   const limitCommands = useRestriction('limitCommands');
 
   const textEnabled = useSelector((state) => state.session.server.textEnabled);
+  const device = useSelector((state) => state.devices.items[deviceId]);
+  const protocol = device?.protocol;
 
   const availableAttributes = useCommandAttributes(t);
 
@@ -54,13 +56,21 @@ const BaseCommandView = ({
     [deviceId, includeSaved, limitCommands],
   );
 
+  const getCommandAttributes = useCallback(
+    (type) =>
+      (availableAttributes[type] || []).filter(
+        (attribute) => !attribute.protocol || !protocol || attribute.protocol === protocol,
+      ),
+    [availableAttributes, protocol],
+  );
+
   useEffect(() => {
     if (item && item.type) {
-      setAttributes(availableAttributes[item.type] || []);
+      setAttributes(getCommandAttributes(item.type));
     } else {
       setAttributes([]);
     }
-  }, [availableAttributes, item]);
+  }, [getCommandAttributes, item]);
 
   const handleSelect = (_, value) => {
     if (value?.optionType === 'saved') {
@@ -69,7 +79,7 @@ const BaseCommandView = ({
     } else if (value?.type) {
       setSavedId?.(0);
       const defaults = {};
-      availableAttributes[value.type]?.forEach((attribute) => {
+      getCommandAttributes(value.type)?.forEach((attribute) => {
         switch (attribute.type) {
           case 'boolean':
             defaults[attribute.key] = false;

--- a/src/settings/components/BaseCommandView.jsx
+++ b/src/settings/components/BaseCommandView.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Autocomplete, Checkbox, FormControlLabel, TextField } from '@mui/material';
 import { useTranslation } from '../../common/components/LocalizationProvider';
@@ -20,8 +20,6 @@ const BaseCommandView = ({
   const limitCommands = useRestriction('limitCommands');
 
   const textEnabled = useSelector((state) => state.session.server.textEnabled);
-  const device = useSelector((state) => state.devices.items[deviceId]);
-  const protocol = device?.protocol;
 
   const availableAttributes = useCommandAttributes(t);
 
@@ -56,21 +54,13 @@ const BaseCommandView = ({
     [deviceId, includeSaved, limitCommands],
   );
 
-  const getCommandAttributes = useCallback(
-    (type) =>
-      (availableAttributes[type] || []).filter(
-        (attribute) => !attribute.protocol || !protocol || attribute.protocol === protocol,
-      ),
-    [availableAttributes, protocol],
-  );
-
   useEffect(() => {
     if (item && item.type) {
-      setAttributes(getCommandAttributes(item.type));
+      setAttributes(availableAttributes[item.type] || []);
     } else {
       setAttributes([]);
     }
-  }, [getCommandAttributes, item]);
+  }, [availableAttributes, item]);
 
   const handleSelect = (_, value) => {
     if (value?.optionType === 'saved') {
@@ -79,7 +69,7 @@ const BaseCommandView = ({
     } else if (value?.type) {
       setSavedId?.(0);
       const defaults = {};
-      getCommandAttributes(value.type)?.forEach((attribute) => {
+      availableAttributes[value.type]?.forEach((attribute) => {
         switch (attribute.type) {
           case 'boolean':
             defaults[attribute.key] = false;


### PR DESCRIPTION
### Summary

Adds the `setSpeedLimit` command to the web UI so the speed limit and the overspeed duration can be configured from the device and saved-command dialogs.

- `useCommandAttributes.js`: define `setSpeedLimit` fields — speed limit (`data`) and overspeed duration in seconds (`duration`).

The `duration` value is only used by the JT808 encoder (JT/T 808-2019 parameter 0x56, written only when provided). Other protocols that support `setSpeedLimit` (e.g. Gator, Khd, HuaSheng) only read the speed value and ignore `duration`.

Reuses existing translation strings — `commandSetSpeedLimit`, `attributeSpeedLimit`, `reportDuration` — no new localization keys are needed.
